### PR TITLE
Feat/nice to have

### DIFF
--- a/gitpulse/config.py
+++ b/gitpulse/config.py
@@ -1,0 +1,169 @@
+"""
+config.py — TOML configuration loader for GitPulse.
+
+Reads ~/.config/gitpulse/config.toml (or a path supplied via --config).
+Uses tomllib (stdlib, Python 3.11+) or tomli (backport, 3.10).
+Missing file → silent fallback to built-in defaults.
+CLI flags always take precedence over config values.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# tomllib is stdlib on 3.11+; tomli is the backport for 3.10
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ImportError:
+        tomllib = None  # type: ignore[assignment]
+
+DEFAULT_CONFIG_PATH = Path("~/.config/gitpulse/config.toml")
+EXAMPLE_CONFIG_PATH = Path("~/.config/gitpulse/config.toml.example")
+
+_EXAMPLE_CONTENT = """\
+# GitPulse configuration — copy to config.toml and edit as needed.
+
+[scan]
+# roots = ["~/projects", "~/work"]   # override --root; list of directories to scan
+
+[author]
+# emails = ["you@example.com"]       # used by digest mode; defaults to git config user.email
+
+[watch]
+enabled = true
+interval_seconds = 5
+
+[stale]
+weeks = 8
+default_branches = ["main", "master", "develop", "trunk"]
+
+[bulk]
+max_workers = 8
+
+[digest]
+default_window = "1d"
+"""
+
+
+@dataclass
+class ScanConfig:
+    roots: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AuthorConfig:
+    emails: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WatchConfig:
+    enabled: bool = True
+    interval_seconds: int = 5
+
+
+@dataclass
+class StaleConfig:
+    weeks: int = 8
+    default_branches: list[str] = field(
+        default_factory=lambda: ["main", "master", "develop", "trunk"]
+    )
+
+
+@dataclass
+class BulkConfig:
+    max_workers: int = 8
+
+
+@dataclass
+class DigestConfig:
+    default_window: str = "1d"
+
+
+@dataclass
+class GitPulseConfig:
+    scan: ScanConfig = field(default_factory=ScanConfig)
+    author: AuthorConfig = field(default_factory=AuthorConfig)
+    watch: WatchConfig = field(default_factory=WatchConfig)
+    stale: StaleConfig = field(default_factory=StaleConfig)
+    bulk: BulkConfig = field(default_factory=BulkConfig)
+    digest: DigestConfig = field(default_factory=DigestConfig)
+
+
+def _write_example_if_missing() -> None:
+    example = EXAMPLE_CONFIG_PATH.expanduser()
+    if not example.exists():
+        try:
+            example.parent.mkdir(parents=True, exist_ok=True)
+            example.write_text(_EXAMPLE_CONTENT)
+        except Exception:
+            pass
+
+
+def load(path: Path | None = None) -> GitPulseConfig:
+    """Load and return the GitPulse configuration.
+
+    Falls back to defaults silently if the file is absent or tomli is
+    unavailable. Writes a .example file on first run.
+    """
+    cfg = GitPulseConfig()
+    _write_example_if_missing()
+
+    config_path = (path or DEFAULT_CONFIG_PATH).expanduser()
+    if not config_path.exists():
+        return cfg
+
+    if tomllib is None:
+        # Python 3.10 without tomli installed — use defaults
+        return cfg
+
+    try:
+        with open(config_path, "rb") as fh:
+            raw = tomllib.load(fh)
+    except Exception:
+        return cfg
+
+    if "scan" in raw:
+        s = raw["scan"]
+        cfg.scan.roots = s.get("roots", [])
+
+    if "author" in raw:
+        a = raw["author"]
+        cfg.author.emails = a.get("emails", [])
+
+    if "watch" in raw:
+        w = raw["watch"]
+        cfg.watch.enabled = bool(w.get("enabled", True))
+        cfg.watch.interval_seconds = int(w.get("interval_seconds", 5))
+
+    if "stale" in raw:
+        st = raw["stale"]
+        cfg.stale.weeks = int(st.get("weeks", 8))
+        cfg.stale.default_branches = list(
+            st.get("default_branches", ["main", "master", "develop", "trunk"])
+        )
+
+    if "bulk" in raw:
+        cfg.bulk.max_workers = int(raw["bulk"].get("max_workers", 8))
+
+    if "digest" in raw:
+        cfg.digest.default_window = str(raw["digest"].get("default_window", "1d"))
+
+    return cfg
+
+
+# Module-level singleton — loaded once, reused everywhere.
+# Call load() explicitly if you need a custom path.
+_default: GitPulseConfig | None = None
+
+
+def get() -> GitPulseConfig:
+    """Return the cached default config (loaded once on first call)."""
+    global _default
+    if _default is None:
+        _default = load()
+    return _default

--- a/gitpulse/digest.py
+++ b/gitpulse/digest.py
@@ -1,0 +1,165 @@
+"""
+digest.py — Activity digest aggregation for GitPulse.
+
+Collects commits authored by a set of email patterns across all scanned repos
+within a time window, groups them by repo, and produces a Digest object.
+Renders as markdown for stdout/clipboard use.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:
+    from gitpulse.git_ops import RepoInfo, AuthorCommit, get_author_commits, get_author_email
+    from gitpulse.parallel import run_parallel
+    from gitpulse.utils import relative_time
+except ImportError:
+    from git_ops import RepoInfo, AuthorCommit, get_author_commits, get_author_email  # type: ignore
+    from parallel import run_parallel  # type: ignore
+    from utils import relative_time  # type: ignore
+
+
+@dataclass
+class RepoDigest:
+    repo: RepoInfo
+    commits: list[AuthorCommit]
+
+    @property
+    def insertions(self) -> int:
+        return sum(c.insertions for c in self.commits)
+
+    @property
+    def deletions(self) -> int:
+        return sum(c.deletions for c in self.commits)
+
+    @property
+    def files_changed(self) -> int:
+        return sum(c.files_changed for c in self.commits)
+
+
+@dataclass
+class Digest:
+    since_ts: float
+    until_ts: float
+    author_patterns: list[str]
+    by_repo: list[RepoDigest] = field(default_factory=list)
+
+    @property
+    def total_commits(self) -> int:
+        return sum(len(rd.commits) for rd in self.by_repo)
+
+    @property
+    def total_insertions(self) -> int:
+        return sum(rd.insertions for rd in self.by_repo)
+
+    @property
+    def total_deletions(self) -> int:
+        return sum(rd.deletions for rd in self.by_repo)
+
+    @property
+    def repos_active(self) -> int:
+        return len(self.by_repo)
+
+
+def _collect_for_repo(
+    args: tuple[RepoInfo, float, list[str]],
+) -> RepoDigest | None:
+    """Worker target: fetch commits for one repo. Returns None if no commits."""
+    repo, since_ts, author_patterns = args
+    all_commits: list[AuthorCommit] = []
+    for pattern in author_patterns:
+        commits = get_author_commits(repo.path, since_ts, pattern)
+        all_commits.extend(commits)
+
+    if not all_commits:
+        return None
+
+    # De-duplicate by hash in case multiple patterns matched same commit
+    seen: set[str] = set()
+    unique: list[AuthorCommit] = []
+    for c in all_commits:
+        if c.short_hash not in seen:
+            seen.add(c.short_hash)
+            unique.append(c)
+
+    unique.sort(key=lambda c: c.ts, reverse=True)
+    return RepoDigest(repo=repo, commits=unique)
+
+
+def _resolve_author_patterns(
+    repos: list[RepoInfo],
+    explicit_patterns: list[str],
+) -> list[str]:
+    """If no explicit patterns given, try to read user.email from the first N repos."""
+    if explicit_patterns:
+        return explicit_patterns
+    emails: set[str] = set()
+    for repo in repos[:5]:
+        email = get_author_email(repo.path)
+        if email:
+            emails.add(email)
+    return list(emails) if emails else []
+
+
+def build_digest(
+    repos: list[RepoInfo],
+    since_ts: float,
+    author_patterns: list[str] | None = None,
+    max_workers: int = 8,
+) -> Digest:
+    """Build a Digest aggregating all matching commits across *repos*."""
+    patterns = _resolve_author_patterns(repos, author_patterns or [])
+    until_ts = time.time()
+
+    if not patterns:
+        return Digest(since_ts=since_ts, until_ts=until_ts, author_patterns=[])
+
+    args_list = [(repo, since_ts, patterns) for repo in repos]
+    results = run_parallel(_collect_for_repo, args_list, max_workers=max_workers)
+
+    by_repo = [
+        result
+        for _, result in results
+        if result is not None and not isinstance(result, Exception)
+    ]
+    by_repo.sort(key=lambda rd: len(rd.commits), reverse=True)
+
+    return Digest(
+        since_ts=since_ts,
+        until_ts=until_ts,
+        author_patterns=patterns,
+        by_repo=by_repo,
+    )
+
+
+def render_markdown(d: Digest) -> str:
+    """Render a Digest as a markdown standup summary."""
+    from datetime import datetime, timezone
+
+    lines: list[str] = []
+    since_str = datetime.fromtimestamp(d.since_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    until_str = datetime.fromtimestamp(d.until_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    authors_str = ", ".join(d.author_patterns) if d.author_patterns else "all authors"
+
+    lines.append(f"# Activity digest — {since_str} → {until_str}")
+    lines.append(f"**Author(s):** {authors_str}  ")
+    lines.append(
+        f"**Summary:** {d.total_commits} commit{'s' if d.total_commits != 1 else ''} "
+        f"across {d.repos_active} repo{'s' if d.repos_active != 1 else ''} "
+        f"· +{d.total_insertions} -{d.total_deletions} lines"
+    )
+    lines.append("")
+
+    for rd in d.by_repo:
+        lines.append(f"## {rd.repo.name} ({len(rd.commits)} commits · +{rd.insertions} -{rd.deletions})")
+        for c in rd.commits:
+            rel = relative_time(c.ts)
+            stats = f"+{c.insertions}/-{c.deletions}" if c.insertions or c.deletions else ""
+            stats_str = f" `{stats}`" if stats else ""
+            lines.append(f"- `{c.short_hash}` {c.message}{stats_str} _{rel}_")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -9,6 +9,7 @@ branches. Uses GitPython for interfacing with local git repositories.
 from __future__ import annotations
 
 import enum
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -70,6 +71,17 @@ class CommitInfo:
     files_changed: int = 0
     insertions: int = 0
     deletions: int = 0
+
+
+@dataclass
+class AuthorCommit:
+    """A single commit attributed to a specific author, used by digest mode."""
+    short_hash: str
+    ts: float
+    message: str
+    insertions: int = 0
+    deletions: int = 0
+    files_changed: int = 0
 
 
 @dataclass
@@ -844,3 +856,84 @@ def get_tracked_files(path: Path) -> list[str]:
         return sorted(p for p in ls_output.splitlines() if p.strip())
     except Exception:
         return []
+
+
+# ===================================================================
+# Author / Digest operations
+# ===================================================================
+
+def get_author_email(path: Path) -> str:
+    """Return the configured git user.email for this repo, or empty string."""
+    repo = _open_repo(path)
+    try:
+        return repo.git.config("user.email").strip()
+    except Exception:
+        return ""
+
+
+def get_author_commits(
+    path: Path,
+    since_ts: float,
+    author_pattern: str,
+) -> list[AuthorCommit]:
+    """Return commits by *author_pattern* in *path* since *since_ts*.
+
+    Uses ``--all`` so commits on any branch are credited. Parses shortstat
+    blocks to extract insertions/deletions without iterating commit objects.
+    """
+    repo = _open_repo(path)
+    commits: list[AuthorCommit] = []
+    try:
+        # Request log with NUL-separated records: hash\x1fts\x1fsubject
+        # then a blank line and the shortstat
+        raw = repo.git.log(
+            "--all",
+            "--no-merges",
+            f"--since=@{int(since_ts)}",
+            f"--author={author_pattern}",
+            "--pretty=format:\x1e%H\x1f%ct\x1f%s",
+            "--shortstat",
+        )
+        if not raw.strip():
+            return []
+
+        # Split on the record separator \x1e (prepended to each commit header)
+        records = [r for r in raw.split("\x1e") if r.strip()]
+        for record in records:
+            lines = record.strip().splitlines()
+            if not lines:
+                continue
+            header_line = lines[0]
+            parts = header_line.split("\x1f", 2)
+            if len(parts) < 3:
+                continue
+            full_hash, ts_str, subject = parts[0].strip(), parts[1], parts[2]
+            try:
+                ts = float(ts_str)
+            except ValueError:
+                continue
+
+            insertions = 0
+            deletions = 0
+            files_changed = 0
+            # shortstat line looks like: "3 files changed, 42 insertions(+), 5 deletions(-)"
+            stat_lines = [l for l in lines[1:] if "changed" in l or "insertion" in l or "deletion" in l]
+            for stat in stat_lines:
+                m_files = re.search(r"(\d+) file", stat)
+                m_ins   = re.search(r"(\d+) insertion", stat)
+                m_del   = re.search(r"(\d+) deletion", stat)
+                if m_files: files_changed = int(m_files.group(1))
+                if m_ins:   insertions    = int(m_ins.group(1))
+                if m_del:   deletions     = int(m_del.group(1))
+
+            commits.append(AuthorCommit(
+                short_hash=full_hash[:7],
+                ts=ts,
+                message=subject.strip(),
+                insertions=insertions,
+                deletions=deletions,
+                files_changed=files_changed,
+            ))
+    except Exception:
+        pass
+    return commits

--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -92,6 +92,21 @@ class BranchInfo:
 
 
 @dataclass
+class BranchDetail:
+    """Rich branch information used by stale-branch analysis."""
+    repo_path: Path
+    repo_name: str
+    name: str
+    last_commit_ts: float
+    last_commit_msg: str
+    is_current: bool
+    has_upstream: bool
+    is_merged_into_default: bool
+    is_wip: bool         # subject matches ^(wip|fixup!|squash!|tmp)\b
+    age_days: int
+
+
+@dataclass
 class StashEntry:
     """A single stash entry."""
     index: int
@@ -891,6 +906,82 @@ def get_tracked_files(path: Path) -> list[str]:
 # ===================================================================
 # Author / Digest operations
 # ===================================================================
+
+def default_branch_for(repo, candidates: list[str] | None = None) -> str | None:
+    """Return the first candidate branch that exists locally, else None."""
+    _candidates = candidates or ["main", "master", "develop", "trunk"]
+    local_names = {b.name for b in repo.branches}
+    for name in _candidates:
+        if name in local_names:
+            return name
+    return None
+
+
+def get_branch_details(
+    path: Path,
+    default_branches: list[str] | None = None,
+) -> list[BranchDetail]:
+    """Return rich details for every local branch in the repo."""
+    import time as _time
+    repo = _open_repo(path)
+    details: list[BranchDetail] = []
+
+    try:
+        current = repo.active_branch.name if not repo.head.is_detached else None
+    except Exception:
+        current = None
+
+    default = default_branch_for(repo, default_branches)
+
+    # Collect merged branches (names only)
+    merged: set[str] = set()
+    if default:
+        try:
+            merged_out = repo.git.branch("--merged", default)
+            for line in merged_out.splitlines():
+                merged.add(line.strip().lstrip("* "))
+        except Exception:
+            pass
+
+    _wip_re = re.compile(r"^(wip|fixup!|squash!|tmp)\b", re.IGNORECASE)
+    now = _time.time()
+
+    try:
+        raw = repo.git.for_each_ref(
+            "refs/heads/",
+            format="%(refname:short)%00%(committerdate:unix)%00%(contents:subject)%00%(upstream:short)%00%(HEAD)",
+        )
+    except Exception:
+        return details
+
+    for line in raw.strip().splitlines():
+        parts = line.split("\x00")
+        if len(parts) < 5:
+            continue
+        bname, ts_str, subject, upstream, head_marker = parts[0], parts[1], parts[2], parts[3], parts[4]
+
+        try:
+            ts = float(ts_str)
+        except ValueError:
+            ts = 0.0
+
+        age_days = int((now - ts) / 86400) if ts else 0
+
+        details.append(BranchDetail(
+            repo_path=path,
+            repo_name=path.name,
+            name=bname,
+            last_commit_ts=ts,
+            last_commit_msg=subject.strip()[:80],
+            is_current=(head_marker.strip() == "*" or bname == current),
+            has_upstream=bool(upstream.strip()),
+            is_merged_into_default=(bname in merged),
+            is_wip=bool(_wip_re.match(subject.strip())),
+            age_days=age_days,
+        ))
+
+    return details
+
 
 def get_author_email(path: Path) -> str:
     """Return the configured git user.email for this repo, or empty string."""

--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -775,6 +775,36 @@ def git_push(path: Path) -> str:
         return f"Error pushing: {exc}"
 
 
+def git_gc(path: Path) -> str:
+    """Run git gc --auto to prune loose objects."""
+    repo = _open_repo(path)
+    try:
+        repo.git.gc("--auto")
+        return "gc --auto completed ✓"
+    except Exception as exc:
+        return f"Error running gc: {exc}"
+
+
+def git_remote_prune(path: Path) -> str:
+    """Run git remote prune origin to remove stale remote-tracking refs."""
+    repo = _open_repo(path)
+    try:
+        result = repo.git.remote("prune", "origin")
+        return result.strip() if result.strip() else "remote prune origin completed ✓"
+    except Exception as exc:
+        return f"Error pruning: {exc}"
+
+
+def git_clean_dry(path: Path) -> str:
+    """Run git clean -nd (dry run) and return untracked file list."""
+    repo = _open_repo(path)
+    try:
+        result = repo.git.clean("-nd")
+        return result.strip() if result.strip() else "Nothing to clean ✓"
+    except Exception as exc:
+        return f"Error running clean: {exc}"
+
+
 # ===================================================================
 # Stash operations
 # ===================================================================

--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -46,6 +46,10 @@ class RepoInfo:
     total_commits: int = 0              # Total commit count on current branch
     contributor_count: int = 0          # Unique author count
     commit_activity: list[int] = field(default_factory=list)  # Commits per week, 7 weeks oldest→newest
+    ahead: int = 0                       # Commits ahead of upstream
+    behind: int = 0                      # Commits behind upstream
+    stash_count: int = 0                 # Number of stash entries
+    has_stale_branches: bool = False     # True if any branch is older than stale threshold
 
 
 @dataclass
@@ -184,6 +188,48 @@ def get_repo_info(path: Path) -> RepoInfo:
         except Exception:
             pass
 
+        # Ahead/behind relative to upstream (skip for detached HEAD)
+        ahead = 0
+        behind = 0
+        try:
+            if branch != "(detached)":
+                _br = repo.active_branch
+                tracking = _br.tracking_branch()
+                if tracking:
+                    ahead = len(list(repo.iter_commits(f"{tracking.name}..{_br.name}")))
+                    behind = len(list(repo.iter_commits(f"{_br.name}..{tracking.name}")))
+        except Exception:
+            pass
+
+        # Stash count
+        stash_count = 0
+        try:
+            sl = repo.git.stash("list")
+            stash_count = len(sl.strip().splitlines()) if sl.strip() else 0
+        except Exception:
+            pass
+
+        # Stale-branch quick check (any local branch older than 8 weeks, not current)
+        has_stale = False
+        try:
+            _stale_cutoff = time.time() - (8 * 7 * 86400)
+            ref_out = repo.git.for_each_ref(
+                "refs/heads/",
+                format="%(refname:short) %(committerdate:unix)",
+            )
+            for _line in ref_out.strip().splitlines():
+                _parts = _line.rsplit(" ", 1)
+                if len(_parts) == 2:
+                    _bname, _ts_str = _parts
+                    try:
+                        if float(_ts_str) < _stale_cutoff and _bname != branch:
+                            has_stale = True
+                            break
+                    except ValueError:
+                        pass
+        except Exception:
+            pass
+
     except (InvalidGitRepositoryError, Exception):
         branch = "unknown"
         status = RepoStatus.CLEAN
@@ -193,6 +239,10 @@ def get_repo_info(path: Path) -> RepoInfo:
         total = 0
         contributor_count = 0
         activity = []
+        ahead = 0
+        behind = 0
+        stash_count = 0
+        has_stale = False
 
     return RepoInfo(
         name=path.name,
@@ -205,6 +255,10 @@ def get_repo_info(path: Path) -> RepoInfo:
         total_commits=total,
         contributor_count=contributor_count,
         commit_activity=activity,
+        ahead=ahead,
+        behind=behind,
+        stash_count=stash_count,
+        has_stale_branches=has_stale,
     )
 
 

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -122,6 +122,15 @@ class GitPulseApp(App):
         if self._watch_enabled:
             cfg = _config.get()
             self.set_interval(cfg.watch.interval_seconds, self._tick_watch)
+            self.sub_title = "watch: ● live"
+        else:
+            self.sub_title = "watch: off"
+        # Focus the repo list so global letter bindings (w/d/b/r) work
+        # without keystrokes being captured by the search Input.
+        try:
+            self.set_focus(self.query_one("#repo-list"))
+        except Exception:
+            pass
 
     # -----------------------------------------------------------------
     # Actions
@@ -224,10 +233,12 @@ class GitPulseApp(App):
         sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
         if self._watch_paused:
             sidebar.update_header(scanning=False, count=len(self._all_repos), live=False)
-            self.notify("Watch mode paused — press w to resume", timeout=3)
+            self.sub_title = "watch: ○ paused"
+            self.notify("⏸  Watch mode PAUSED — press w to resume", severity="warning", timeout=4)
         else:
             sidebar.update_header(scanning=False, count=len(self._all_repos), live=True)
-            self.notify("Watch mode resumed ●", timeout=2)
+            self.sub_title = "watch: ● live"
+            self.notify("▶  Watch mode RESUMED — auto-refresh on", severity="information", timeout=3)
 
     def action_search(self) -> None:
         """Focus the search input (bound to '/')."""

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -29,6 +29,8 @@ try:
     from gitpulse.ui.tabs import MainPanel
     from gitpulse.ui.fleet_status import FleetStatus
     from gitpulse.ui.digest_screen import DigestScreen
+    from gitpulse.ui.command_palette import CommandPaletteModal
+    from gitpulse.ui.bulk_results import BulkResultsScreen
     from gitpulse.utils import __version__, parse_since
     from gitpulse import config as _config
     from gitpulse import watcher as _watcher
@@ -43,6 +45,8 @@ except ImportError:
     from ui.tabs import MainPanel  # type: ignore[no-redef]
     from ui.fleet_status import FleetStatus  # type: ignore[no-redef]
     from ui.digest_screen import DigestScreen  # type: ignore[no-redef]
+    from ui.command_palette import CommandPaletteModal  # type: ignore[no-redef]
+    from ui.bulk_results import BulkResultsScreen  # type: ignore[no-redef]
     from utils import __version__, parse_since  # type: ignore[no-redef]
     import config as _config  # type: ignore[no-redef]
     import watcher as _watcher  # type: ignore[no-redef]
@@ -67,6 +71,7 @@ class GitPulseApp(App):
         Binding("r", "refresh", "Refresh", show=True),
         Binding("w", "toggle_watch", "Watch", show=True),
         Binding("d", "open_digest", "Digest", show=True),
+        Binding("colon", "open_palette", "Actions", show=True),
         Binding("slash", "search", "Search", show=True),
         Binding("escape", "clear_search", "Clear", show=False),
         Binding("tab", "focus_next", "Next", show=False),
@@ -135,6 +140,70 @@ class GitPulseApp(App):
             author_patterns=cfg.author.emails or [],
             default_window=cfg.digest.default_window,
         ))
+
+    def action_open_palette(self) -> None:
+        """Open the bulk-action command palette (bound to ':')."""
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        sel_count = len(sidebar.selected_repos())
+
+        async def _after_palette(result: tuple | None) -> None:
+            if result is None:
+                return
+            action_key, scope = result
+            if scope == "selected":
+                target_repos = sidebar.selected_repos()
+            elif scope == "all":
+                target_repos = list(self._all_repos)
+            else:
+                target_repos = [self._selected_repo] if self._selected_repo else []
+
+            if not target_repos:
+                self.notify("No repos to act on", timeout=2)
+                return
+
+            # Push needs extra confirmation
+            if action_key == "push":
+                names = ", ".join(r.name for r in target_repos[:5])
+                extra = f" +{len(target_repos) - 5} more" if len(target_repos) > 5 else ""
+                self.notify(f"Pushing to: {names}{extra}", timeout=4)
+
+            self._dispatch_bulk(action_key, target_repos)
+
+        self.push_screen(CommandPaletteModal(selected_count=sel_count), _after_palette)
+
+    def _dispatch_bulk(self, action_key: str, repos: list) -> None:
+        """Fan out a bulk git operation over repos using a thread pool worker."""
+        from gitpulse.git_ops import git_fetch, git_pull, git_push, git_gc, git_remote_prune, git_clean_dry, get_repo_info
+        from gitpulse.parallel import run_parallel
+
+        _ops = {
+            "fetch":   lambda r: git_fetch(r.path),
+            "pull":    lambda r: git_pull(r.path),
+            "push":    lambda r: git_push(r.path),
+            "gc":      lambda r: git_gc(r.path),
+            "prune":   lambda r: git_remote_prune(r.path),
+            "clean":   lambda r: git_clean_dry(r.path),
+            "refresh": lambda r: get_repo_info(r.path),
+        }
+        op = _ops.get(action_key)
+        if op is None:
+            self.notify(f"Unknown action: {action_key}", severity="error", timeout=3)
+            return
+
+        cfg = _config.get()
+        results_screen = BulkResultsScreen(action=action_key, total=len(repos))
+        self.push_screen(results_screen)
+
+        def _worker() -> None:
+            def _progress(completed, total, repo, result):
+                self.call_from_thread(results_screen.append_row, repo, result)
+
+            run_parallel(op, repos, max_workers=cfg.bulk.max_workers, on_progress=_progress)
+            # After bulk refresh, trigger a rescan to update sidebar
+            if action_key in ("pull", "refresh"):
+                self.call_from_thread(self._start_scan)
+
+        self.run_worker(_worker, thread=True, group="bulk", exclusive=False)
 
     def action_toggle_watch(self) -> None:
         """Pause / resume watch mode (bound to 'w')."""
@@ -318,6 +387,12 @@ class GitPulseApp(App):
     def on_repo_sidebar_search_changed(self, message: RepoSidebar.SearchChanged) -> None:
         """User typed in the search bar."""
         self._apply_filter(message.query)
+
+    def on_repo_sidebar_selection_changed(self, message: RepoSidebar.SelectionChanged) -> None:
+        """Update the header when the multi-select set changes."""
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        live = self._watch_enabled and not self._watch_paused
+        sidebar.update_header(scanning=False, count=len(self._all_repos), live=live)
 
     def on_fleet_status_filter_requested(self, message: FleetStatus.FilterRequested) -> None:
         """User clicked a fleet chip — filter sidebar to matching repos."""

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -28,7 +28,8 @@ try:
     from gitpulse.ui.sidebar import RepoSidebar
     from gitpulse.ui.tabs import MainPanel
     from gitpulse.ui.fleet_status import FleetStatus
-    from gitpulse.utils import __version__
+    from gitpulse.ui.digest_screen import DigestScreen
+    from gitpulse.utils import __version__, parse_since
     from gitpulse import config as _config
     from gitpulse import watcher as _watcher
 except ImportError:
@@ -41,7 +42,8 @@ except ImportError:
     from ui.sidebar import RepoSidebar  # type: ignore[no-redef]
     from ui.tabs import MainPanel  # type: ignore[no-redef]
     from ui.fleet_status import FleetStatus  # type: ignore[no-redef]
-    from utils import __version__  # type: ignore[no-redef]
+    from ui.digest_screen import DigestScreen  # type: ignore[no-redef]
+    from utils import __version__, parse_since  # type: ignore[no-redef]
     import config as _config  # type: ignore[no-redef]
     import watcher as _watcher  # type: ignore[no-redef]
 
@@ -64,6 +66,7 @@ class GitPulseApp(App):
         Binding("q", "quit", "Quit", show=True),
         Binding("r", "refresh", "Refresh", show=True),
         Binding("w", "toggle_watch", "Watch", show=True),
+        Binding("d", "open_digest", "Digest", show=True),
         Binding("slash", "search", "Search", show=True),
         Binding("escape", "clear_search", "Clear", show=False),
         Binding("tab", "focus_next", "Next", show=False),
@@ -123,6 +126,15 @@ class GitPulseApp(App):
             return
         self._start_scan()
         self.notify("Scanning repositories… ⚡", timeout=2)
+
+    def action_open_digest(self) -> None:
+        """Open the activity digest modal (bound to 'd')."""
+        cfg = _config.get()
+        self.push_screen(DigestScreen(
+            repos=self._all_repos,
+            author_patterns=cfg.author.emails or [],
+            default_window=cfg.digest.default_window,
+        ))
 
     def action_toggle_watch(self) -> None:
         """Pause / resume watch mode (bound to 'w')."""
@@ -375,6 +387,27 @@ def parse_args() -> argparse.Namespace:
         help="Disable live watch mode (default: enabled)",
     )
     parser.add_argument(
+        "--digest",
+        action="store_true",
+        default=False,
+        help="Print activity digest as markdown and exit (no TUI)",
+    )
+    parser.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        metavar="SPEC",
+        help="Time window for --digest: 1d, 7d, 30d, yesterday, YYYY-MM-DD (default: 1d)",
+    )
+    parser.add_argument(
+        "--author",
+        action="append",
+        dest="authors",
+        metavar="EMAIL",
+        default=None,
+        help="Author email filter for --digest (repeatable; default: git config user.email)",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"gitpulse {__version__}",
@@ -397,6 +430,28 @@ def main() -> None:
         sys.exit(1)
 
     cfg = _config.get()
+
+    if args.digest:
+        # CLI digest mode — no TUI
+        from gitpulse.scanner import scan_repos as _scan
+        from gitpulse.git_ops import get_repo_info as _gri
+        from gitpulse.digest import build_digest as _bd, render_markdown as _rm
+        from gitpulse.utils import parse_since as _ps
+
+        since_spec = args.since or cfg.digest.default_window
+        try:
+            since_ts = _ps(since_spec)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        author_patterns = args.authors or cfg.author.emails or []
+        paths = _scan(root)
+        repos = [_gri(p) for p in paths]
+        digest = _bd(repos, since_ts, author_patterns, max_workers=cfg.bulk.max_workers)
+        print(_rm(digest))
+        return
+
     watch_enabled = cfg.watch.enabled and not args.no_watch
     app = GitPulseApp(root_dir=root, commits=args.commits, watch=watch_enabled)
     app.run()

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -31,6 +31,7 @@ try:
     from gitpulse.ui.digest_screen import DigestScreen
     from gitpulse.ui.command_palette import CommandPaletteModal
     from gitpulse.ui.bulk_results import BulkResultsScreen
+    from gitpulse.ui.stale_screen import StaleScreen
     from gitpulse.utils import __version__, parse_since
     from gitpulse import config as _config
     from gitpulse import watcher as _watcher
@@ -47,6 +48,7 @@ except ImportError:
     from ui.digest_screen import DigestScreen  # type: ignore[no-redef]
     from ui.command_palette import CommandPaletteModal  # type: ignore[no-redef]
     from ui.bulk_results import BulkResultsScreen  # type: ignore[no-redef]
+    from ui.stale_screen import StaleScreen  # type: ignore[no-redef]
     from utils import __version__, parse_since  # type: ignore[no-redef]
     import config as _config  # type: ignore[no-redef]
     import watcher as _watcher  # type: ignore[no-redef]
@@ -72,6 +74,7 @@ class GitPulseApp(App):
         Binding("w", "toggle_watch", "Watch", show=True),
         Binding("d", "open_digest", "Digest", show=True),
         Binding("colon", "open_palette", "Actions", show=True),
+        Binding("b", "open_stale", "Stale", show=True),
         Binding("slash", "search", "Search", show=True),
         Binding("escape", "clear_search", "Clear", show=False),
         Binding("tab", "focus_next", "Next", show=False),
@@ -139,6 +142,16 @@ class GitPulseApp(App):
             repos=self._all_repos,
             author_patterns=cfg.author.emails or [],
             default_window=cfg.digest.default_window,
+        ))
+
+    def action_open_stale(self) -> None:
+        """Open stale-branch cleanup modal (bound to 'b')."""
+        cfg = _config.get()
+        self.push_screen(StaleScreen(
+            repo_paths=[r.path for r in self._all_repos],
+            stale_weeks=cfg.stale.weeks,
+            default_branches=cfg.stale.default_branches,
+            max_workers=cfg.bulk.max_workers,
         ))
 
     def action_open_palette(self) -> None:

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -28,6 +28,7 @@ try:
     from gitpulse.ui.sidebar import RepoSidebar
     from gitpulse.ui.tabs import MainPanel
     from gitpulse.utils import __version__
+    from gitpulse import config as _config
 except ImportError:
     # Running directly: python main.py
     _THIS_DIR = Path(__file__).resolve().parent
@@ -38,6 +39,7 @@ except ImportError:
     from ui.sidebar import RepoSidebar  # type: ignore[no-redef]
     from ui.tabs import MainPanel  # type: ignore[no-redef]
     from utils import __version__  # type: ignore[no-redef]
+    import config as _config  # type: ignore[no-redef]
 
 
 class GitPulseApp(App):
@@ -126,7 +128,7 @@ class GitPulseApp(App):
             sidebar.update_header(scanning=True)
         except Exception:
             pass
-        self.run_worker(self._scan_worker, thread=True, exclusive=True)
+        self.run_worker(self._scan_worker, thread=True, exclusive=True, group="scan")
 
     def _scan_worker(self) -> list[RepoInfo]:
         """Worker function: scan filesystem and collect RepoInfo objects.
@@ -247,6 +249,13 @@ def parse_args() -> argparse.Namespace:
         help="Number of commits to display per repo (default: 10)",
     )
     parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to config.toml (default: ~/.config/gitpulse/config.toml)",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"gitpulse {__version__}",
@@ -257,6 +266,11 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """Entry point — called by both `python main.py` and the `gitpulse` command."""
     args = parse_args()
+
+    # Load config (custom path takes precedence)
+    if args.config:
+        _config.load(Path(args.config))
+
     root = Path(args.root).expanduser().resolve()
 
     if not root.is_dir():

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.widgets import Header, Footer, Input
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.worker import Worker, WorkerState
 
 # Support both installed-package imports (gitpulse.scanner) and
@@ -27,6 +27,7 @@ try:
     from gitpulse.git_ops import get_repo_info, switch_branch, RepoInfo
     from gitpulse.ui.sidebar import RepoSidebar
     from gitpulse.ui.tabs import MainPanel
+    from gitpulse.ui.fleet_status import FleetStatus
     from gitpulse.utils import __version__
     from gitpulse import config as _config
 except ImportError:
@@ -38,6 +39,7 @@ except ImportError:
     from git_ops import get_repo_info, switch_branch, RepoInfo  # type: ignore[no-redef]
     from ui.sidebar import RepoSidebar  # type: ignore[no-redef]
     from ui.tabs import MainPanel  # type: ignore[no-redef]
+    from ui.fleet_status import FleetStatus  # type: ignore[no-redef]
     from utils import __version__  # type: ignore[no-redef]
     import config as _config  # type: ignore[no-redef]
 
@@ -81,7 +83,9 @@ class GitPulseApp(App):
     def compose(self) -> ComposeResult:
         yield Header()
         with Horizontal(id="app-grid"):
-            yield RepoSidebar(id="sidebar-container")
+            with Vertical(id="sidebar-column"):
+                yield FleetStatus(id="fleet-status")
+                yield RepoSidebar(id="sidebar-container")
             yield MainPanel(id="main-panel", commits=self.commits)
         yield Footer()
 
@@ -153,6 +157,9 @@ class GitPulseApp(App):
             sidebar.update_header(scanning=False, count=len(infos))
             sidebar.populate(self.repos)
 
+            fleet: FleetStatus = self.query_one("#fleet-status", FleetStatus)
+            fleet.update_counters(infos)
+
             if self.repos:
                 self._select_repo(self.repos[0])
 
@@ -182,6 +189,27 @@ class GitPulseApp(App):
 
         sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
         sidebar.populate(self.repos)
+        if self.repos:
+            self._select_repo(self.repos[0])
+
+    def _apply_fleet_filter(self, category: str) -> None:
+        """Filter sidebar to repos matching a fleet-status category."""
+        from gitpulse.git_ops import RepoStatus  # avoid circular at module level
+        _predicates = {
+            "dirty":   lambda r: r.status != RepoStatus.CLEAN,
+            "behind":  lambda r: r.behind > 0,
+            "ahead":   lambda r: r.ahead > 0,
+            "stashes": lambda r: r.stash_count > 0,
+            "stale":   lambda r: r.has_stale_branches,
+        }
+        pred = _predicates.get(category)
+        if pred is None:
+            self.repos = list(self._all_repos)
+        else:
+            self.repos = [r for r in self._all_repos if pred(r)]
+
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        sidebar.populate(self.repos)
 
         if self.repos:
             self._select_repo(self.repos[0])
@@ -197,6 +225,10 @@ class GitPulseApp(App):
     def on_repo_sidebar_search_changed(self, message: RepoSidebar.SearchChanged) -> None:
         """User typed in the search bar."""
         self._apply_filter(message.query)
+
+    def on_fleet_status_filter_requested(self, message: FleetStatus.FilterRequested) -> None:
+        """User clicked a fleet chip — filter sidebar to matching repos."""
+        self._apply_fleet_filter(message.category)
 
     def on_main_panel_branch_switch_requested(
         self, message: MainPanel.BranchSwitchRequested

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -30,6 +30,7 @@ try:
     from gitpulse.ui.fleet_status import FleetStatus
     from gitpulse.utils import __version__
     from gitpulse import config as _config
+    from gitpulse import watcher as _watcher
 except ImportError:
     # Running directly: python main.py
     _THIS_DIR = Path(__file__).resolve().parent
@@ -42,6 +43,7 @@ except ImportError:
     from ui.fleet_status import FleetStatus  # type: ignore[no-redef]
     from utils import __version__  # type: ignore[no-redef]
     import config as _config  # type: ignore[no-redef]
+    import watcher as _watcher  # type: ignore[no-redef]
 
 
 class GitPulseApp(App):
@@ -61,13 +63,20 @@ class GitPulseApp(App):
     BINDINGS = [
         Binding("q", "quit", "Quit", show=True),
         Binding("r", "refresh", "Refresh", show=True),
+        Binding("w", "toggle_watch", "Watch", show=True),
         Binding("slash", "search", "Search", show=True),
         Binding("escape", "clear_search", "Clear", show=False),
         Binding("tab", "focus_next", "Next", show=False),
         Binding("shift+tab", "focus_previous", "Prev", show=False),
     ]
 
-    def __init__(self, root_dir: Path, commits: int = 10, **kwargs) -> None:
+    def __init__(
+        self,
+        root_dir: Path,
+        commits: int = 10,
+        watch: bool = True,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.root_dir = root_dir
         self.commits = commits          # How many commits to show in Commits tab
@@ -75,6 +84,9 @@ class GitPulseApp(App):
         self._all_repos: list[RepoInfo] = []  # Unfiltered master list
         self._selected_repo: RepoInfo | None = None
         self._scanning = False          # Guard against concurrent scans
+        self._watch_enabled = watch     # Whether watch mode is on
+        self._watch_paused = False      # Toggled by 'w' key
+        self._signatures: dict = {}     # path → (HEAD mtime, index mtime, refs mtime)
 
     # -----------------------------------------------------------------
     # Layout
@@ -94,8 +106,11 @@ class GitPulseApp(App):
     # -----------------------------------------------------------------
 
     def on_mount(self) -> None:
-        """Initial scan on startup."""
+        """Initial scan on startup; start watch-mode interval if enabled."""
         self._start_scan()
+        if self._watch_enabled:
+            cfg = _config.get()
+            self.set_interval(cfg.watch.interval_seconds, self._tick_watch)
 
     # -----------------------------------------------------------------
     # Actions
@@ -108,6 +123,17 @@ class GitPulseApp(App):
             return
         self._start_scan()
         self.notify("Scanning repositories… ⚡", timeout=2)
+
+    def action_toggle_watch(self) -> None:
+        """Pause / resume watch mode (bound to 'w')."""
+        self._watch_paused = not self._watch_paused
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        if self._watch_paused:
+            sidebar.update_header(scanning=False, count=len(self._all_repos), live=False)
+            self.notify("Watch mode paused — press w to resume", timeout=3)
+        else:
+            sidebar.update_header(scanning=False, count=len(self._all_repos), live=True)
+            self.notify("Watch mode resumed ●", timeout=2)
 
     def action_search(self) -> None:
         """Focus the search input (bound to '/')."""
@@ -148,13 +174,26 @@ class GitPulseApp(App):
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         """Called on the main thread when the worker finishes."""
         if event.state == WorkerState.SUCCESS and event.worker.result is not None:
+            group = getattr(event.worker, "group", None)
+
+            if group == "watch":
+                # Single-repo refresh from watch tick
+                updated: RepoInfo = event.worker.result
+                self._refresh_single_repo(updated)
+                return
+
+            # Full scan result
             self._scanning = False
             infos: list[RepoInfo] = event.worker.result
             self._all_repos = infos
             self.repos = list(infos)
 
+            # Snapshot signatures for watch mode
+            self._signatures = _watcher.snapshot(infos)
+
             sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
-            sidebar.update_header(scanning=False, count=len(infos))
+            live = self._watch_enabled and not self._watch_paused
+            sidebar.update_header(scanning=False, count=len(infos), live=live)
             sidebar.populate(self.repos)
 
             fleet: FleetStatus = self.query_one("#fleet-status", FleetStatus)
@@ -166,6 +205,48 @@ class GitPulseApp(App):
         elif event.state == WorkerState.ERROR:
             self._scanning = False
             self.notify(f"Scan failed: {event.worker.error}", severity="error", timeout=5)
+
+    def _tick_watch(self) -> None:
+        """Called on a timer interval — check for changed repos and re-enrich them."""
+        if self._watch_paused or not self._all_repos:
+            return
+        changed = _watcher.changed_repos(self._all_repos, self._signatures)
+        for repo in changed:
+            # Update signature immediately to avoid re-triggering before worker completes
+            self._signatures[repo.path] = _watcher.repo_signature(repo.path)
+            path = repo.path
+            self.run_worker(
+                lambda p=path: get_repo_info(p),
+                thread=True,
+                group="watch",
+                exclusive=False,
+            )
+
+    def _refresh_single_repo(self, updated: RepoInfo) -> None:
+        """Apply a single watch-refresh result without re-populating the whole list."""
+        # Update master list in place
+        for i, r in enumerate(self._all_repos):
+            if r.path == updated.path:
+                self._all_repos[i] = updated
+                break
+        else:
+            self._all_repos.append(updated)
+
+        # Re-sort by activity
+        self._all_repos.sort(key=lambda r: r.last_commit_ts, reverse=True)
+        self.repos = list(self._all_repos)
+
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        sidebar.populate(self.repos)
+
+        fleet: FleetStatus = self.query_one("#fleet-status", FleetStatus)
+        fleet.update_counters(self._all_repos)
+
+        # If the updated repo is selected, refresh the main panel too
+        if self._selected_repo and self._selected_repo.path == updated.path:
+            self._selected_repo = updated
+            main: MainPanel = self.query_one("#main-panel", MainPanel)
+            main.load_repo(updated.path, updated)
 
     # -----------------------------------------------------------------
     # Internal helpers
@@ -288,6 +369,12 @@ def parse_args() -> argparse.Namespace:
         help="Path to config.toml (default: ~/.config/gitpulse/config.toml)",
     )
     parser.add_argument(
+        "--no-watch",
+        action="store_true",
+        default=False,
+        help="Disable live watch mode (default: enabled)",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"gitpulse {__version__}",
@@ -309,7 +396,9 @@ def main() -> None:
         print(f"Error: '{root}' is not a valid directory.", file=sys.stderr)
         sys.exit(1)
 
-    app = GitPulseApp(root_dir=root, commits=args.commits)
+    cfg = _config.get()
+    watch_enabled = cfg.watch.enabled and not args.no_watch
+    app = GitPulseApp(root_dir=root, commits=args.commits, watch=watch_enabled)
     app.run()
 
 

--- a/gitpulse/parallel.py
+++ b/gitpulse/parallel.py
@@ -1,0 +1,61 @@
+"""
+parallel.py — Thread-pool fan-out helper for GitPulse.
+
+Provides a simple run_parallel() utility that fans a function out over a list
+of items using a bounded thread pool. Used by digest, bulk-ops, and stale-branch
+features to avoid blocking the Textual main thread.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def run_parallel(
+    fn: Callable[[T], R],
+    items: list[T],
+    max_workers: int = 8,
+    on_progress: Callable[[int, int, T, R | Exception], None] | None = None,
+) -> list[tuple[T, R | Exception]]:
+    """Fan *fn* out over *items* using a thread pool, return ordered results.
+
+    Args:
+        fn: Callable taking one item, returning a result.
+        items: List of inputs to process.
+        max_workers: Thread-pool ceiling (default 8).
+        on_progress: Optional callback invoked after each future completes.
+            Called with (completed_count, total_count, item, result_or_exception).
+            Fires from worker threads — UI consumers must marshal via
+            ``app.call_from_thread``.
+
+    Returns:
+        List of ``(item, result)`` tuples in the same order as *items*.
+        If *fn* raises, the exception is captured and stored as the result
+        rather than propagated, so all items are always represented.
+    """
+    if not items:
+        return []
+
+    total = len(items)
+    results: dict[int, R | Exception] = {}
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, total)) as pool:
+        future_to_idx = {pool.submit(fn, item): i for i, item in enumerate(items)}
+        completed = 0
+        for future in as_completed(future_to_idx):
+            idx = future_to_idx[future]
+            item = items[idx]
+            try:
+                result: R | Exception = future.result()
+            except Exception as exc:
+                result = exc
+            results[idx] = result
+            completed += 1
+            if on_progress is not None:
+                on_progress(completed, total, item, result)
+
+    return [(items[i], results[i]) for i in range(total)]

--- a/gitpulse/stale.py
+++ b/gitpulse/stale.py
@@ -1,0 +1,84 @@
+"""
+stale.py — Stale-branch analysis for GitPulse.
+
+Categorises local branches across all repos into stale, merged, WIP, and
+unmerged groups. Provides a quick-check used by get_repo_info() and a full
+scan used by StaleScreen.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    from gitpulse.git_ops import BranchDetail, get_branch_details
+    from gitpulse.parallel import run_parallel
+except ImportError:
+    from git_ops import BranchDetail, get_branch_details  # type: ignore
+    from parallel import run_parallel  # type: ignore
+
+
+def categorize(
+    branches: list[BranchDetail],
+    stale_weeks: int = 8,
+) -> dict[str, list[BranchDetail]]:
+    """Split *branches* into named categories.
+
+    Returns dict with keys: "all", "stale", "merged", "wip", "unmerged".
+    Branches can appear in multiple categories (e.g. stale AND merged).
+    """
+    cutoff_days = stale_weeks * 7
+    result: dict[str, list[BranchDetail]] = {
+        "all":      list(branches),
+        "stale":    [],
+        "merged":   [],
+        "wip":      [],
+        "unmerged": [],
+    }
+    for b in branches:
+        if b.is_current:
+            continue  # Never flag the checked-out branch
+        if b.age_days >= cutoff_days and not b.is_merged_into_default:
+            result["stale"].append(b)
+        if b.is_merged_into_default:
+            result["merged"].append(b)
+        if b.is_wip:
+            result["wip"].append(b)
+        if not b.is_merged_into_default and not b.is_current:
+            result["unmerged"].append(b)
+
+    return result
+
+
+def count_stale_quick(
+    path: Path,
+    stale_weeks: int = 8,
+    default_branches: list[str] | None = None,
+) -> int:
+    """Lightweight stale-branch count for sidebar enrichment.
+
+    Returns the number of non-current branches older than *stale_weeks* that
+    are not merged into the default branch.
+    """
+    details = get_branch_details(path, default_branches)
+    cats = categorize(details, stale_weeks)
+    return len(cats["stale"])
+
+
+def gather_all_repos(
+    repo_paths: list[Path],
+    stale_weeks: int = 8,
+    default_branches: list[str] | None = None,
+    max_workers: int = 8,
+) -> dict[str, list[BranchDetail]]:
+    """Fan out get_branch_details across all repos and return merged categories."""
+    def _fetch(path: Path) -> list[BranchDetail]:
+        return get_branch_details(path, default_branches)
+
+    results = run_parallel(_fetch, repo_paths, max_workers=max_workers)
+    all_branches: list[BranchDetail] = []
+    for _, res in results:
+        if isinstance(res, list):
+            all_branches.extend(res)
+
+    return categorize(all_branches, stale_weeks)

--- a/gitpulse/ui/bulk_results.py
+++ b/gitpulse/ui/bulk_results.py
@@ -1,0 +1,110 @@
+"""
+bulk_results.py — Live results screen for bulk git operations.
+
+Shown after a bulk operation is dispatched; rows update as futures complete.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Static
+from textual.containers import Container
+
+try:
+    from gitpulse.git_ops import RepoInfo
+except ImportError:
+    from git_ops import RepoInfo  # type: ignore[no-redef]
+
+
+class BulkResultsScreen(ModalScreen):
+    """Modal showing per-repo results from a bulk operation."""
+
+    BINDINGS = [Binding("escape,q", "close", "Close", show=True)]
+
+    DEFAULT_CSS = """
+    BulkResultsScreen {
+        align: center middle;
+    }
+    #results-frame {
+        width: 88%;
+        height: 75%;
+        background: #1e2030;
+        border: thick #bb9af7;
+    }
+    #results-title {
+        dock: top;
+        height: 1;
+        background: #24283b;
+        color: #bb9af7;
+        text-style: bold;
+        padding: 0 1;
+    }
+    #results-table {
+        width: 100%;
+        height: 1fr;
+    }
+    #results-footer {
+        dock: bottom;
+        height: 1;
+        background: #1e2030;
+        color: #565f89;
+        padding: 0 1;
+        border-top: solid #3b4261;
+    }
+    """
+
+    def __init__(self, action: str, total: int, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._action = action
+        self._total = total
+        self._completed = 0
+
+    def compose(self) -> ComposeResult:
+        with Container(id="results-frame"):
+            yield Static(
+                f" Bulk: {self._action}",
+                id="results-title",
+                markup=False,
+            )
+            yield DataTable(id="results-table")
+            yield Static(
+                f"  0/{self._total} complete · Esc/q to close",
+                id="results-footer",
+                markup=False,
+            )
+
+    def on_mount(self) -> None:
+        table: DataTable = self.query_one("#results-table", DataTable)
+        table.add_columns("Repo", "Status", "Output")
+        table.cursor_type = "row"
+        table.zebra_stripes = True
+
+    def append_row(self, repo: RepoInfo, result: str | Exception) -> None:
+        """Add a completed row. Safe to call from any thread via call_from_thread."""
+        table: DataTable = self.query_one("#results-table", DataTable)
+        self._completed += 1
+
+        if isinstance(result, Exception):
+            status = "[bold #f7768e]ERROR[/]"
+            output = str(result)[:80]
+        elif isinstance(result, str) and result.lower().startswith("error"):
+            status = "[bold #f7768e]FAIL[/]"
+            output = result[:80]
+        else:
+            status = "[bold #9ece6a]OK[/]"
+            output = (str(result) if result else "done")[:80]
+
+        table.add_row(repo.name, status, output)
+
+        footer: Static = self.query_one("#results-footer", Static)
+        done = self._completed == self._total
+        suffix = "  (done — Esc/q to close)" if done else " · Esc/q to close"
+        footer.update(
+            f"  {self._completed}/{self._total} complete{suffix}",
+            markup=False,
+        )
+
+    def action_close(self) -> None:
+        self.dismiss()

--- a/gitpulse/ui/command_palette.py
+++ b/gitpulse/ui/command_palette.py
@@ -1,0 +1,135 @@
+"""
+command_palette.py — Fuzzy-search command palette modal for GitPulse.
+
+Opened with ':' to pick a bulk operation to run across selected (or all) repos.
+Returns (action_key, scope) to the caller via dismiss().
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import ModalScreen
+from textual.widgets import Input, ListItem, ListView, Static
+from textual.containers import Container
+
+# Available bulk actions: (key, label, description)
+BULK_ACTIONS: list[tuple[str, str, str]] = [
+    ("fetch",   "fetch",          "git fetch --all from each repo"),
+    ("pull",    "pull",           "git pull from tracking branch"),
+    ("push",    "push",           "git push to tracking branch (asks confirmation)"),
+    ("gc",      "gc --auto",      "git gc --auto — prune loose objects"),
+    ("prune",   "remote prune",   "git remote prune origin — remove stale remote refs"),
+    ("clean",   "clean -nd",      "git clean -nd — dry-run show untracked files"),
+    ("refresh", "status refresh", "Re-scan and refresh repo info"),
+]
+
+
+class CommandPaletteModal(ModalScreen):
+    """Fuzzy command palette for selecting a bulk action."""
+
+    BINDINGS = [Binding("escape", "close", "Cancel", show=True)]
+
+    DEFAULT_CSS = """
+    CommandPaletteModal {
+        align: center middle;
+    }
+    #palette-frame {
+        width: 60;
+        height: auto;
+        max-height: 24;
+        padding: 1 2;
+        background: #1e2030;
+        border: thick #7aa2f7;
+    }
+    #palette-title {
+        text-style: bold;
+        color: #7aa2f7;
+        margin-bottom: 1;
+        text-align: center;
+        width: 100%;
+        height: 1;
+    }
+    #palette-scope {
+        color: #e0af68;
+        margin-bottom: 1;
+        width: 100%;
+        height: 1;
+    }
+    #palette-input {
+        width: 100%;
+        margin-bottom: 1;
+    }
+    #palette-list {
+        width: 100%;
+        height: auto;
+        max-height: 12;
+    }
+    """
+
+    def __init__(self, selected_count: int = 0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._selected_count = selected_count
+        self._filtered = list(BULK_ACTIONS)
+
+    def compose(self) -> ComposeResult:
+        scope_text = (
+            f"{self._selected_count} selected repo{'s' if self._selected_count != 1 else ''}"
+            if self._selected_count > 0
+            else "current repo"
+        )
+        with Container(id="palette-frame"):
+            yield Static("⚡ Bulk Action", id="palette-title", markup=False)
+            yield Static(f"  Scope: {scope_text}", id="palette-scope", markup=False)
+            yield Input(placeholder="Filter actions…", id="palette-input")
+            yield ListView(id="palette-list")
+
+    def on_mount(self) -> None:
+        self._rebuild_list(self._filtered)
+        self.query_one("#palette-input", Input).focus()
+
+    def _rebuild_list(self, actions: list[tuple[str, str, str]]) -> None:
+        lv: ListView = self.query_one("#palette-list", ListView)
+        lv.clear()
+        for key, label, desc in actions:
+            lv.append(ListItem(
+                Static(f"[bold #9ece6a]{label}[/]  [dim #565f89]{desc}[/]", markup=True),
+                id=f"action-{key}",
+            ))
+        if actions:
+            lv.index = 0
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        q = event.value.strip().lower()
+        if q:
+            self._filtered = [
+                a for a in BULK_ACTIONS
+                if q in a[0] or q in a[1].lower() or q in a[2].lower()
+            ]
+        else:
+            self._filtered = list(BULK_ACTIONS)
+        self._rebuild_list(self._filtered)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        self._submit()
+
+    def _submit(self) -> None:
+        lv: ListView = self.query_one("#palette-list", ListView)
+        item = lv.highlighted_child
+        if item is None and self._filtered:
+            # If nothing highlighted but there's a match, pick first
+            self._dispatch(self._filtered[0][0])
+            return
+        if item is not None and item.id and item.id.startswith("action-"):
+            key = item.id.removeprefix("action-")
+            self._dispatch(key)
+
+    def _dispatch(self, key: str) -> None:
+        scope = "selected" if self._selected_count > 0 else "current"
+        self.dismiss((key, scope))
+
+    def action_close(self) -> None:
+        self.dismiss(None)

--- a/gitpulse/ui/digest_screen.py
+++ b/gitpulse/ui/digest_screen.py
@@ -178,8 +178,8 @@ class DigestScreen(ModalScreen):
             lines.append(
                 f"\n[bold #bb9af7]📁 {rd.repo.name}[/]  "
                 f"[dim]{len(rd.commits)} commit{'s' if len(rd.commits) != 1 else ''}  "
-                f"[#9ece6a]+{rd.insertions}[/dim #9ece6a] "
-                f"[#f7768e]-{rd.deletions}[/dim #f7768e][dim][/]"
+                f"[#9ece6a]+{rd.insertions}[/]"
+                f" [#f7768e]-{rd.deletions}[/][/dim]"
             )
             for c in rd.commits:
                 rel = relative_time(c.ts)

--- a/gitpulse/ui/digest_screen.py
+++ b/gitpulse/ui/digest_screen.py
@@ -1,0 +1,222 @@
+"""
+digest_screen.py — Activity digest TUI modal for GitPulse.
+
+Full-screen modal accessed via 'D' in the main app. Shows commits by the
+current user(s) across all scanned repos in a configurable time window.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import ModalScreen
+from textual.widgets import Static, Button
+from textual.containers import Container, ScrollableContainer, Horizontal
+
+try:
+    from gitpulse.digest import Digest, build_digest, render_markdown
+    from gitpulse.git_ops import RepoInfo
+    from gitpulse.utils import parse_since, relative_time
+except ImportError:
+    from digest import Digest, build_digest, render_markdown  # type: ignore
+    from git_ops import RepoInfo  # type: ignore
+    from utils import parse_since, relative_time  # type: ignore
+
+
+_WINDOWS = {
+    "1": ("1d", "Today"),
+    "7": ("7d", "7 days"),
+    "3": ("30d", "30 days"),
+}
+
+
+class DigestScreen(ModalScreen):
+    """Full-screen activity digest modal."""
+
+    BINDINGS = [
+        Binding("escape,q", "close", "Close", show=True),
+        Binding("1", "window_1d", "Today", show=True),
+        Binding("7", "window_7d", "7d", show=True),
+        Binding("3", "window_30d", "30d", show=True),
+        Binding("m", "copy_markdown", "Copy MD", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    DigestScreen {
+        align: center middle;
+    }
+    #digest-frame {
+        width: 95%;
+        height: 90%;
+        background: #1e2030;
+        border: thick #7aa2f7;
+    }
+    #digest-header {
+        dock: top;
+        height: 3;
+        background: #24283b;
+        color: #7aa2f7;
+        text-style: bold;
+        padding: 0 2;
+        border-bottom: heavy #3b4261;
+        layout: horizontal;
+        align: left middle;
+    }
+    #digest-window-label {
+        width: auto;
+        color: #bb9af7;
+        margin-left: 2;
+    }
+    #digest-scroll {
+        width: 100%;
+        height: 1fr;
+        padding: 0 1;
+    }
+    #digest-body {
+        padding: 1 1;
+    }
+    #digest-footer {
+        dock: bottom;
+        height: 1;
+        background: #1e2030;
+        color: #565f89;
+        padding: 0 1;
+        border-top: solid #3b4261;
+    }
+    """
+
+    def __init__(
+        self,
+        repos: list[RepoInfo],
+        author_patterns: list[str] | None = None,
+        default_window: str = "1d",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._repos = repos
+        self._author_patterns = author_patterns or []
+        self._window = default_window
+        self._digest: Digest | None = None
+
+    def compose(self) -> ComposeResult:
+        with Container(id="digest-frame"):
+            with Horizontal(id="digest-header"):
+                yield Static("📋 Activity Digest", markup=False)
+                yield Static("", id="digest-window-label")
+            with ScrollableContainer(id="digest-scroll"):
+                yield Static(
+                    "[dim italic]Loading digest…[/]",
+                    id="digest-body",
+                    markup=True,
+                )
+            yield Static(
+                "  1=today  7=7d  3=30d  m=copy markdown  Esc/q=close",
+                id="digest-footer",
+                markup=False,
+            )
+
+    def on_mount(self) -> None:
+        self._load_digest()
+
+    def _load_digest(self) -> None:
+        label: Static = self.query_one("#digest-window-label", Static)
+        label.update(f"[#bb9af7]window: {self._window}[/]")
+
+        body: Static = self.query_one("#digest-body", Static)
+        body.update("[dim italic]Computing digest…[/]")
+
+        try:
+            since_ts = parse_since(self._window)
+        except ValueError as e:
+            body.update(f"[bold #f7768e]Error: {e}[/]")
+            return
+
+        # Run in a worker so we don't block the UI
+        self.run_worker(
+            lambda: build_digest(self._repos, since_ts, self._author_patterns),
+            thread=True,
+            group="digest",
+        )
+
+    def on_worker_state_changed(self, event) -> None:
+        from textual.worker import WorkerState
+        if event.state == WorkerState.SUCCESS and event.worker.result is not None:
+            self._digest = event.worker.result
+            self._render_digest()
+        elif event.state == WorkerState.ERROR:
+            body: Static = self.query_one("#digest-body", Static)
+            body.update(f"[bold #f7768e]Error building digest: {event.worker.error}[/]")
+
+    def _render_digest(self) -> None:
+        d = self._digest
+        if d is None:
+            return
+
+        body: Static = self.query_one("#digest-body", Static)
+
+        if d.total_commits == 0:
+            body.update(
+                "[dim italic]  No commits found for this window and author pattern.[/]\n"
+                "[dim #565f89]  Tip: configure author emails in ~/.config/gitpulse/config.toml[/]"
+            )
+            return
+
+        lines: list[str] = []
+        since_str = datetime.fromtimestamp(d.since_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+        lines.append(
+            f"[bold #7aa2f7]{d.total_commits}[/] commits across "
+            f"[bold #9ece6a]{d.repos_active}[/] repos  "
+            f"[#9ece6a]+{d.total_insertions}[/] [#f7768e]-{d.total_deletions}[/] lines  "
+            f"[dim]since {since_str} UTC[/]"
+        )
+        lines.append("[dim #3b4261]─" * 60 + "[/]")
+
+        for rd in d.by_repo:
+            lines.append(
+                f"\n[bold #bb9af7]📁 {rd.repo.name}[/]  "
+                f"[dim]{len(rd.commits)} commit{'s' if len(rd.commits) != 1 else ''}  "
+                f"[#9ece6a]+{rd.insertions}[/dim #9ece6a] "
+                f"[#f7768e]-{rd.deletions}[/dim #f7768e][dim][/]"
+            )
+            for c in rd.commits:
+                rel = relative_time(c.ts)
+                stats = f"[#9ece6a]+{c.insertions}[/] [#f7768e]-{c.deletions}[/]" if (c.insertions or c.deletions) else ""
+                msg = c.message[:70]
+                lines.append(
+                    f"  [dim #7aa2f7]{c.short_hash}[/]  {msg}"
+                    f"  {stats}  [dim #565f89]{rel}[/]"
+                )
+
+        body.update("\n".join(lines))
+
+    def action_window_1d(self) -> None:
+        self._window = "1d"
+        self._load_digest()
+
+    def action_window_7d(self) -> None:
+        self._window = "7d"
+        self._load_digest()
+
+    def action_window_30d(self) -> None:
+        self._window = "30d"
+        self._load_digest()
+
+    def action_copy_markdown(self) -> None:
+        if self._digest is None:
+            self.app.notify("No digest to copy yet", timeout=2)
+            return
+        md = render_markdown(self._digest)
+        try:
+            import pyperclip
+            pyperclip.copy(md)
+            self.app.notify("Markdown copied to clipboard ✓", timeout=3)
+        except Exception:
+            self.app.notify("pyperclip not available — printed to stderr", timeout=3)
+            import sys
+            print(md, file=sys.stderr)
+
+    def action_close(self) -> None:
+        self.dismiss()

--- a/gitpulse/ui/fleet_status.py
+++ b/gitpulse/ui/fleet_status.py
@@ -1,0 +1,115 @@
+"""
+fleet_status.py — Cross-repo fleet status bar for GitPulse.
+
+Shows live counters (dirty, behind, unpushed, stashes, stale branches) across
+all scanned repositories. Each chip is clickable and posts a FilterRequested
+message so the sidebar can narrow to just the matching repos.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+try:
+    from gitpulse.git_ops import RepoInfo, RepoStatus
+except ImportError:
+    from git_ops import RepoInfo, RepoStatus  # type: ignore[no-redef]
+
+
+class FleetChip(Static):
+    """A single clickable counter chip in the fleet status bar."""
+
+    DEFAULT_CSS = """
+    FleetChip {
+        width: auto;
+        height: 1;
+        padding: 0 1;
+        margin: 0 1;
+        content-align: center middle;
+    }
+    FleetChip:hover {
+        background: #283457;
+    }
+    """
+
+    def __init__(self, category: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.category = category
+
+    def on_click(self) -> None:
+        self.post_message(FleetStatus.FilterRequested(self.category))
+
+
+class FleetStatus(Widget):
+    """
+    Horizontal bar pinned above the sidebar showing cross-repo health counters.
+
+    Counters:
+    - dirty     — repos with uncommitted changes
+    - behind    — total commits behind upstream (sum)
+    - ahead     — repos with unpushed commits
+    - stashes   — total stash entries (sum)
+    - stale     — repos with stale local branches
+    """
+
+    DEFAULT_CSS = """
+    FleetStatus {
+        height: 3;
+        background: #1e2030;
+        border-bottom: heavy #3b4261;
+        layout: horizontal;
+        align: left middle;
+        padding: 0 1;
+    }
+    FleetStatus > Static#fleet-label {
+        width: auto;
+        color: #565f89;
+        margin-right: 1;
+    }
+    """
+
+    class FilterRequested(Message):
+        """Posted when a chip is clicked; carries the category to filter by."""
+
+        def __init__(self, category: str) -> None:
+            super().__init__()
+            self.category = category
+
+    def compose(self) -> ComposeResult:
+        yield Static("fleet:", id="fleet-label", markup=False)
+        yield FleetChip("dirty",   id="chip-dirty")
+        yield FleetChip("behind",  id="chip-behind")
+        yield FleetChip("ahead",   id="chip-ahead")
+        yield FleetChip("stashes", id="chip-stashes")
+        yield FleetChip("stale",   id="chip-stale")
+
+    def on_mount(self) -> None:
+        self._set_chip("chip-dirty",   "🔴", 0, "#f7768e")
+        self._set_chip("chip-behind",  "↓",  0, "#f7768e")
+        self._set_chip("chip-ahead",   "↑",  0, "#e0af68")
+        self._set_chip("chip-stashes", "📦", 0, "#7aa2f7")
+        self._set_chip("chip-stale",   "💀", 0, "#bb9af7")
+
+    def update_counters(self, repos: list[RepoInfo]) -> None:
+        """Recompute all chips from the current repo list."""
+        n_dirty        = sum(1 for r in repos if r.status != RepoStatus.CLEAN)
+        total_behind   = sum(r.behind for r in repos)
+        n_ahead        = sum(1 for r in repos if r.ahead > 0)
+        total_stashes  = sum(r.stash_count for r in repos)
+        n_stale        = sum(1 for r in repos if r.has_stale_branches)
+
+        self._set_chip("chip-dirty",   "🔴", n_dirty,       "#f7768e")
+        self._set_chip("chip-behind",  "↓",  total_behind,  "#f7768e")
+        self._set_chip("chip-ahead",   "↑",  n_ahead,       "#e0af68")
+        self._set_chip("chip-stashes", "📦", total_stashes, "#7aa2f7")
+        self._set_chip("chip-stale",   "💀", n_stale,       "#bb9af7")
+
+    def _set_chip(self, widget_id: str, icon: str, count: int, color: str) -> None:
+        chip: FleetChip = self.query_one(f"#{widget_id}", FleetChip)
+        if count == 0:
+            chip.update(f"[dim #565f89]{icon} 0[/]")
+        else:
+            chip.update(f"[bold {color}]{icon} {count}[/]")

--- a/gitpulse/ui/sidebar.py
+++ b/gitpulse/ui/sidebar.py
@@ -136,17 +136,32 @@ class RepoSidebar(Static):
         )
         yield ListView(id="repo-list")
 
-    def update_header(self, scanning: bool, count: int = 0) -> None:
-        """Update the title bar to show scanning state or repo count."""
+    def update_header(
+        self,
+        scanning: bool,
+        count: int = 0,
+        live: bool | None = None,
+    ) -> None:
+        """Update the title bar to show scanning state or repo count.
+
+        *live* controls the watch indicator: True = green dot, False = dim dot,
+        None = unchanged from last render.
+        """
         title: Static = self.query_one("#sidebar-title", Static)
         if scanning:
             title.update("⚡ [bold #7aa2f7]GitPulse[/]  [dim #565f89]scanning…[/]")
+            return
+        count_str = (
+            f"[dim #565f89]{count} repo{'s' if count != 1 else ''}[/]"
+            if count else ""
+        )
+        if live is True:
+            live_str = "  [bold #9ece6a]●live[/]"
+        elif live is False:
+            live_str = "  [dim #565f89]○paused[/]"
         else:
-            count_str = (
-                f"[dim #565f89]{count} repo{'s' if count != 1 else ''}[/]"
-                if count else ""
-            )
-            title.update(f"⚡ [bold #7aa2f7]GitPulse[/]  {count_str}")
+            live_str = ""
+        title.update(f"⚡ [bold #7aa2f7]GitPulse[/]{live_str}  {count_str}")
 
     def populate(self, repos: list[RepoInfo]) -> None:
         """Clear and re-populate the repo list."""

--- a/gitpulse/ui/sidebar.py
+++ b/gitpulse/ui/sidebar.py
@@ -3,10 +3,13 @@ sidebar.py — Repo list sidebar widget for GitPulse.
 
 Displays all discovered repositories in a scrollable ListView with
 color-coded status badges, branch names, relative time, and file counts.
-Includes a search/filter input at the top.
+Includes a search/filter input at the top and multi-select support for
+bulk operations.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 from textual.app import ComposeResult
 from textual.message import Message
@@ -72,9 +75,10 @@ class RepoListItem(ListItem):
     }
     """
 
-    def __init__(self, repo_info: RepoInfo, **kwargs) -> None:
+    def __init__(self, repo_info: RepoInfo, selected: bool = False, **kwargs) -> None:
         super().__init__(**kwargs)
         self.repo_info = repo_info
+        self._selected = selected
 
     def compose(self) -> ComposeResult:
         info = self.repo_info
@@ -82,20 +86,26 @@ class RepoListItem(ListItem):
         rel = relative_time(info.last_commit_ts)
         spark = _sparkline(info.commit_activity)
 
-        # Line 1: repo name  +  badge
-        line1 = f"[bold #c0caf5]{info.name}[/]  {badge}"
+        # Selection checkbox prefix
+        if self._selected:
+            checkbox = "[bold #9ece6a][✓][/] "
+        else:
+            checkbox = "[dim #3b4261][ ][/] "
+
+        # Line 1: checkbox + repo name + badge
+        line1 = f"{checkbox}[bold #c0caf5]{info.name}[/]  {badge}"
         # Line 2: branch  |  relative time  |  sparkline
-        line2 = f"  [#bb9af7]⎇ {info.branch}[/]  [dim #565f89]⏱ {rel}[/]  {spark}"
+        line2 = f"   [#bb9af7]⎇ {info.branch}[/]  [dim #565f89]⏱ {rel}[/]  {spark}"
         # Line 3: truncated last commit message for quick context
         commit_msg = info.last_commit_msg
         if len(commit_msg) > 36:
             commit_msg = commit_msg[:35] + "…"
-        line3 = f"  [dim #565f89]💬 {commit_msg}[/]" if commit_msg else "  [dim #3b4261]no commits[/]"
+        line3 = f"   [dim #565f89]💬 {commit_msg}[/]" if commit_msg else "   [dim #3b4261]no commits[/]"
         # Line 4: truncated repo path for disambiguation
         path_str = str(info.path)
         if len(path_str) > 38:
             path_str = "…" + path_str[-37:]
-        line4 = f"  [dim #3b4261]{path_str}[/]"
+        line4 = f"   [dim #3b4261]{path_str}[/]"
 
         yield Static(f"{line1}\n{line2}\n{line3}\n{line4}", markup=True)
 
@@ -109,7 +119,8 @@ class RepoSidebar(Static):
     Left sidebar panel: title + search input + scrollable list of repos.
 
     Posts a `RepoSidebar.RepoSelected` message when the user highlights
-    a different repo, and `RepoSidebar.SearchChanged` when the filter changes.
+    a different repo, `RepoSidebar.SearchChanged` when the filter changes,
+    and `RepoSidebar.SelectionChanged` when the multi-select set changes.
     """
 
     class RepoSelected(Message):
@@ -123,6 +134,64 @@ class RepoSidebar(Static):
         def __init__(self, query: str) -> None:
             super().__init__()
             self.query = query
+
+    class SelectionChanged(Message):
+        """Fired when the multi-select set changes."""
+        def __init__(self, count: int, paths: list[Path]) -> None:
+            super().__init__()
+            self.count = count
+            self.paths = paths
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._selected: set[Path] = set()
+        self._current_repos: list[RepoInfo] = []
+
+    # ── Multi-select API ────────────────────────────────────────────────
+
+    def is_selected(self, path: Path) -> bool:
+        return path in self._selected
+
+    def toggle(self, path: Path) -> None:
+        if path in self._selected:
+            self._selected.discard(path)
+        else:
+            self._selected.add(path)
+        self._post_selection_changed()
+
+    def select_all_visible(self) -> None:
+        for r in self._current_repos:
+            self._selected.add(r.path)
+        self._post_selection_changed()
+        self.populate(self._current_repos)
+
+    def clear_selection(self) -> None:
+        self._selected.clear()
+        self._post_selection_changed()
+        self.populate(self._current_repos)
+
+    def selected_repos(self) -> list[RepoInfo]:
+        return [r for r in self._current_repos if r.path in self._selected]
+
+    def _post_selection_changed(self) -> None:
+        self.post_message(self.SelectionChanged(
+            count=len(self._selected),
+            paths=list(self._selected),
+        ))
+        # Update the header to show selection count
+        self._update_selection_indicator()
+
+    def _update_selection_indicator(self) -> None:
+        try:
+            title: Static = self.query_one("#sidebar-title", Static)
+            sel = len(self._selected)
+            if sel > 0:
+                # Append selection count to current title markup — regenerate
+                pass  # handled in update_header when called after populate
+        except Exception:
+            pass
+
+    # ── Compose ─────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -161,15 +230,19 @@ class RepoSidebar(Static):
             live_str = "  [dim #565f89]○paused[/]"
         else:
             live_str = ""
-        title.update(f"⚡ [bold #7aa2f7]GitPulse[/]{live_str}  {count_str}")
+
+        sel = len(self._selected)
+        sel_str = f"  [bold #e0af68][{sel} sel][/]" if sel > 0 else ""
+
+        title.update(f"⚡ [bold #7aa2f7]GitPulse[/]{live_str}  {count_str}{sel_str}")
 
     def populate(self, repos: list[RepoInfo]) -> None:
         """Clear and re-populate the repo list."""
+        self._current_repos = list(repos)
         list_view: ListView = self.query_one("#repo-list", ListView)
         list_view.clear()
 
         if not repos:
-            # Friendly empty state
             from textual.widgets import ListItem as _LI
             list_view.append(_LI(Static(
                 "[dim italic #565f89]\n  📂  No repositories found\n"
@@ -180,7 +253,7 @@ class RepoSidebar(Static):
             return
 
         for info in repos:
-            list_view.append(RepoListItem(info))
+            list_view.append(RepoListItem(info, selected=info.path in self._selected))
 
         # Auto-select first item
         list_view.index = 0
@@ -194,6 +267,19 @@ class RepoSidebar(Static):
         """Forward search input changes."""
         if event.input.id == "search-input":
             self.post_message(self.SearchChanged(event.value))
+
+    def on_key(self, event) -> None:
+        """Handle multi-select keys: Space toggles, * selects all."""
+        if event.key == "space":
+            lv: ListView = self.query_one("#repo-list", ListView)
+            item = lv.highlighted_child
+            if isinstance(item, RepoListItem):
+                self.toggle(item.repo_info.path)
+                self.populate(self._current_repos)
+                event.stop()
+        elif event.key == "asterisk":
+            self.select_all_visible()
+            event.stop()
 
     def focus_search(self) -> None:
         """Focus the search input."""

--- a/gitpulse/ui/stale_screen.py
+++ b/gitpulse/ui/stale_screen.py
@@ -1,0 +1,282 @@
+"""
+stale_screen.py — Stale-branch cleanup modal for GitPulse.
+
+Opened with 'B' to show branches across all repos matching stale/merged/WIP
+criteria. Supports multi-select and bulk delete with a typed confirmation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import ModalScreen
+from textual.widgets import DataTable, Input, Static, Button, TabbedContent, TabPane
+from textual.containers import Container, Vertical, Horizontal
+
+try:
+    from gitpulse.git_ops import BranchDetail, delete_branch
+    from gitpulse.stale import gather_all_repos, categorize
+    from gitpulse.parallel import run_parallel
+    from gitpulse.utils import relative_time
+except ImportError:
+    from git_ops import BranchDetail, delete_branch  # type: ignore
+    from stale import gather_all_repos, categorize  # type: ignore
+    from parallel import run_parallel  # type: ignore
+    from utils import relative_time  # type: ignore
+
+
+class DeleteConfirmModal(ModalScreen):
+    """Type-to-confirm modal for bulk branch deletion."""
+
+    BINDINGS = [Binding("escape", "close", "Cancel", show=True)]
+
+    DEFAULT_CSS = """
+    DeleteConfirmModal { align: center middle; }
+    #dconf-frame {
+        width: 56;
+        height: auto;
+        padding: 1 2;
+        background: #1e2030;
+        border: thick #f7768e;
+    }
+    #dconf-title { color: #f7768e; text-style: bold; margin-bottom: 1; }
+    #dconf-info  { color: #e0af68; margin-bottom: 1; }
+    #dconf-input { width: 100%; margin-bottom: 1; }
+    #dconf-btns  { layout: horizontal; width: 100%; height: 3; align: center middle; }
+    """
+
+    def __init__(self, count: int, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._count = count
+        self._phrase = f"delete {count} branch{'es' if count != 1 else ''}"
+
+    def compose(self) -> ComposeResult:
+        with Container(id="dconf-frame"):
+            yield Static(f"⚠ Delete {self._count} branch{'es' if self._count != 1 else ''}?", id="dconf-title", markup=False)
+            yield Static(f'  Type exactly: {self._phrase}', id="dconf-info", markup=False)
+            yield Input(placeholder=self._phrase, id="dconf-input")
+            with Horizontal(id="dconf-btns"):
+                yield Button("Delete", id="btn-confirm-del", variant="error")
+                yield Button("Cancel", id="btn-cancel-del")
+
+    def on_mount(self) -> None:
+        self.query_one("#dconf-input", Input).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-confirm-del":
+            self._try_confirm()
+        else:
+            self.dismiss(False)
+
+    def on_input_submitted(self, _) -> None:
+        self._try_confirm()
+
+    def _try_confirm(self) -> None:
+        val = self.query_one("#dconf-input", Input).value.strip()
+        if val == self._phrase:
+            self.dismiss(True)
+        else:
+            self.query_one("#dconf-info", Static).update(
+                f"  ✗ Must match exactly: {self._phrase}", markup=False
+            )
+
+    def action_close(self) -> None:
+        self.dismiss(False)
+
+
+class StaleScreen(ModalScreen):
+    """Full-screen stale-branch explorer and cleanup modal."""
+
+    BINDINGS = [
+        Binding("escape,q", "close", "Close", show=True),
+        Binding("space", "toggle_row", "Select", show=True),
+        Binding("asterisk", "select_all", "Select All", show=True),
+        Binding("d", "delete_selected", "Delete", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    StaleScreen { align: center middle; }
+    #stale-frame {
+        width: 96%;
+        height: 90%;
+        background: #1e2030;
+        border: thick #bb9af7;
+    }
+    #stale-header {
+        dock: top;
+        height: 1;
+        background: #24283b;
+        color: #bb9af7;
+        text-style: bold;
+        padding: 0 1;
+    }
+    #stale-tabs { height: 1fr; }
+    #stale-footer {
+        dock: bottom;
+        height: 1;
+        background: #1e2030;
+        color: #565f89;
+        padding: 0 1;
+        border-top: solid #3b4261;
+    }
+    """
+
+    def __init__(
+        self,
+        repo_paths: list[Path],
+        stale_weeks: int = 8,
+        default_branches: list[str] | None = None,
+        max_workers: int = 8,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._repo_paths = repo_paths
+        self._stale_weeks = stale_weeks
+        self._default_branches = default_branches or ["main", "master", "develop", "trunk"]
+        self._max_workers = max_workers
+        self._categories: dict[str, list[BranchDetail]] = {}
+        self._selected: set[tuple[str, str]] = set()  # (repo_name, branch_name)
+        self._active_category = "stale"
+
+    def compose(self) -> ComposeResult:
+        with Container(id="stale-frame"):
+            yield Static(" 💀 Stale Branches", id="stale-header", markup=False)
+            with TabbedContent(id="stale-tabs"):
+                for cat, label in [
+                    ("stale",    f"Stale ({self._stale_weeks}w+)"),
+                    ("merged",   "Merged"),
+                    ("wip",      "WIP"),
+                    ("unmerged", "Unmerged"),
+                    ("all",      "All"),
+                ]:
+                    with TabPane(label, id=f"stale-tab-{cat}"):
+                        yield DataTable(id=f"stale-table-{cat}")
+            yield Static(
+                "  Space=select  *=all  d=delete selected  Esc/q=close",
+                id="stale-footer",
+                markup=False,
+            )
+
+    def on_mount(self) -> None:
+        for cat in ("stale", "merged", "wip", "unmerged", "all"):
+            table: DataTable = self.query_one(f"#stale-table-{cat}", DataTable)
+            table.add_columns("[ ]", "Repo", "Branch", "Age", "Last commit", "Flags")
+            table.cursor_type = "row"
+            table.zebra_stripes = True
+
+        self._load_data()
+
+    def _load_data(self) -> None:
+        self.query_one("#stale-header", Static).update(
+            " 💀 Stale Branches  [dim #565f89]loading…[/]"
+        )
+        self.run_worker(self._fetch_worker, thread=True, group="stale")
+
+    def _fetch_worker(self) -> dict[str, list[BranchDetail]]:
+        return gather_all_repos(
+            self._repo_paths,
+            self._stale_weeks,
+            self._default_branches,
+            self._max_workers,
+        )
+
+    def on_worker_state_changed(self, event) -> None:
+        from textual.worker import WorkerState
+        if event.state == WorkerState.SUCCESS and event.worker.result is not None:
+            self._categories = event.worker.result
+            self._populate_tables()
+            self.query_one("#stale-header", Static).update(" 💀 Stale Branches")
+        elif event.state == WorkerState.ERROR:
+            self.query_one("#stale-header", Static).update(
+                f" 💀 Error: {event.worker.error}"
+            )
+
+    def _populate_tables(self) -> None:
+        for cat, branches in self._categories.items():
+            table: DataTable = self.query_one(f"#stale-table-{cat}", DataTable)
+            table.clear()
+            for b in sorted(branches, key=lambda x: x.age_days, reverse=True):
+                sel_key = (b.repo_name, b.name)
+                checkbox = "[bold #9ece6a]✓[/]" if sel_key in self._selected else "[ ]"
+                flags = []
+                if b.is_wip:            flags.append("[#e0af68]WIP[/]")
+                if b.is_merged_into_default: flags.append("[#9ece6a]merged[/]")
+                if b.is_current:        flags.append("[#7aa2f7]current[/]")
+                if not b.has_upstream:  flags.append("[dim]no-remote[/]")
+                flags_str = " ".join(flags) if flags else "[dim]—[/]"
+                age_str = f"{b.age_days}d"
+                msg = b.last_commit_msg[:40] + ("…" if len(b.last_commit_msg) > 40 else "")
+                table.add_row(checkbox, b.repo_name, b.name, age_str, msg, flags_str)
+
+    def _current_table_and_category(self) -> tuple[DataTable, str]:
+        try:
+            tc = self.query_one(TabbedContent)
+            pane_id = str(tc.active) if tc.active else "stale-tab-stale"
+            cat = pane_id.removeprefix("stale-tab-")
+        except Exception:
+            cat = "stale"
+        table: DataTable = self.query_one(f"#stale-table-{cat}", DataTable)
+        return table, cat
+
+    def _branch_at_cursor(self) -> BranchDetail | None:
+        table, cat = self._current_table_and_category()
+        if table.cursor_row < 0:
+            return None
+        branches = self._categories.get(cat, [])
+        sorted_branches = sorted(branches, key=lambda x: x.age_days, reverse=True)
+        if table.cursor_row < len(sorted_branches):
+            return sorted_branches[table.cursor_row]
+        return None
+
+    def action_toggle_row(self) -> None:
+        b = self._branch_at_cursor()
+        if b is None or b.is_current:
+            return
+        key = (b.repo_name, b.name)
+        if key in self._selected:
+            self._selected.discard(key)
+        else:
+            self._selected.add(key)
+        self._populate_tables()
+
+    def action_select_all(self) -> None:
+        _, cat = self._current_table_and_category()
+        for b in self._categories.get(cat, []):
+            if not b.is_current:
+                self._selected.add((b.repo_name, b.name))
+        self._populate_tables()
+
+    def action_delete_selected(self) -> None:
+        if not self._selected:
+            self.app.notify("Nothing selected — use Space to select branches", timeout=3)
+            return
+
+        async def _after_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            # Collect BranchDetail objects for selected
+            to_delete: list[BranchDetail] = []
+            for cat_branches in self._categories.values():
+                for b in cat_branches:
+                    if (b.repo_name, b.name) in self._selected:
+                        if b not in to_delete:
+                            to_delete.append(b)
+
+            def _do_delete(b: BranchDetail) -> str:
+                return delete_branch(b.repo_path, b.name, force=True)
+
+            results = run_parallel(_do_delete, to_delete, max_workers=self._max_workers)
+            ok = sum(1 for _, r in results if not isinstance(r, Exception) and not str(r).startswith("Error"))
+            fail = len(results) - ok
+            self.app.notify(f"Deleted {ok} branch{'es' if ok != 1 else ''}" + (f", {fail} failed" if fail else ""), timeout=4)
+
+            self._selected.clear()
+            self._load_data()
+            self.app.post_message_no_wait = getattr(self.app, "post_message_no_wait", None)
+
+        self.app.push_screen(DeleteConfirmModal(count=len(self._selected)), _after_confirm)
+
+    def action_close(self) -> None:
+        self.dismiss()

--- a/gitpulse/ui/styles.tcss
+++ b/gitpulse/ui/styles.tcss
@@ -15,12 +15,18 @@ Screen {
     height: 1fr;
 }
 
-#sidebar-container {
+#sidebar-column {
     width: 46;
     min-width: 32;
     max-width: 58;
     background: #16161e;
     border-right: vkey #3b4261;
+}
+
+#sidebar-container {
+    width: 100%;
+    height: 1fr;
+    background: #16161e;
 }
 
 #main-panel {

--- a/gitpulse/ui/tabs.py
+++ b/gitpulse/ui/tabs.py
@@ -848,21 +848,30 @@ class MainPanel(Widget):
         graph_text = get_commit_graph(repo_path, max(self._commits_n, 40))
         graph_static: Static = self.query_one("#commits-graph", Static)
         if graph_text and not graph_text.startswith("Error"):
-            # Colorize graph characters for visual richness
+            # Colorize graph characters using sentinels so successive
+            # replacements can't feed into each other (a literal '/' from
+            # an earlier '[/]' insertion must not be re-substituted).
             colored_lines: list[str] = []
+            STAR, PIPE, SLASH, BACK = "\x01", "\x02", "\x03", "\x04"
             for line in graph_text.splitlines():
-                # Highlight the short hash (7 hex chars after the graph art)
-                line_esc = re.sub(
-                    r'\b([0-9a-f]{7})\b',
-                    r'[bold #7aa2f7]\1[/]',
-                    line,
+                tagged = (
+                    line.replace("*", STAR)
+                        .replace("|", PIPE)
+                        .replace("/", SLASH)
+                        .replace("\\", BACK)
                 )
-                # Colorize graph structure characters
-                line_esc = line_esc.replace("*", "[#bb9af7]*[/]")
-                line_esc = line_esc.replace("|", "[#3b4261]|[/]")
-                line_esc = line_esc.replace("/", "[#3b4261]/[/]")
-                line_esc = line_esc.replace("\\", "[#3b4261]\\[/]")
-                colored_lines.append(line_esc)
+                tagged = re.sub(
+                    r"\b([0-9a-f]{7})\b",
+                    r"[bold #7aa2f7]\1[/]",
+                    tagged,
+                )
+                tagged = (
+                    tagged.replace(STAR, "[#bb9af7]*[/]")
+                          .replace(PIPE, "[#3b4261]|[/]")
+                          .replace(SLASH, "[#3b4261]/[/]")
+                          .replace(BACK, "[#3b4261]\\\\[/]")
+                )
+                colored_lines.append(tagged)
             graph_static.update("\n".join(colored_lines))
         else:
             graph_static.update(f"[dim italic]{graph_text or 'No commits'}[/]")
@@ -879,7 +888,7 @@ class MainPanel(Widget):
         hints: Static = self.query_one("#commits-hints", Static)
         hints.update(
             f"[dim #565f89]  {len(commits)} commits · "
-            f"[#9ece6a]+{total_ins}[/dim #565f89] / [#f7768e]-{total_del}[/dim #565f89] lines · "
+            f"[#9ece6a]+{total_ins}[/] / [#f7768e]-{total_del}[/] lines · "
             f"{total_files} files · {authors} author{'s' if authors != 1 else ''} · "
             f"Enter or d = view diff[/]"
         )

--- a/gitpulse/utils.py
+++ b/gitpulse/utils.py
@@ -7,7 +7,8 @@ need to live inside domain-specific files (e.g. git_ops.py).
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timezone, timedelta
 
 # ---------------------------------------------------------------------------
 # Package version — single source of truth
@@ -19,6 +20,47 @@ __version__ = "1.2.0"
 # ---------------------------------------------------------------------------
 # Time helpers
 # ---------------------------------------------------------------------------
+
+def parse_since(spec: str) -> float:
+    """Parse a time-window spec into a Unix timestamp (start of the window).
+
+    Supported forms:
+        Nd  — N days ago      (e.g. "1d", "7d")
+        Nw  — N weeks ago     (e.g. "2w")
+        Nh  — N hours ago     (e.g. "4h")
+        yesterday             — start of the previous calendar day (midnight)
+        today                 — start of the current calendar day (midnight)
+        YYYY-MM-DD            — specific date (midnight)
+        YYYY-MM-DDTHH:MM      — specific datetime
+
+    Raises ValueError for unrecognised formats.
+    """
+    spec = spec.strip().lower()
+    now = datetime.now(timezone.utc)
+
+    if spec == "yesterday":
+        d = (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+        return d.timestamp()
+    if spec == "today":
+        d = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return d.timestamp()
+
+    m = re.fullmatch(r"(\d+)([hdw])", spec)
+    if m:
+        n, unit = int(m.group(1)), m.group(2)
+        delta = {"h": timedelta(hours=n), "d": timedelta(days=n), "w": timedelta(weeks=n)}[unit]
+        return (now - delta).timestamp()
+
+    # ISO date or datetime
+    for fmt in ("%Y-%m-%dt%H:%M", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(spec, fmt).replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            pass
+
+    raise ValueError(f"Unrecognised time spec: {spec!r}. Try '1d', '7d', 'yesterday', or 'YYYY-MM-DD'.")
+
 
 def relative_time(ts: float) -> str:
     """Convert a Unix timestamp to a human-readable relative time string.

--- a/gitpulse/watcher.py
+++ b/gitpulse/watcher.py
@@ -1,0 +1,62 @@
+"""
+watcher.py — Filesystem polling helpers for GitPulse watch mode.
+
+Polls .git/HEAD, .git/index, and .git/refs/heads/ mtimes to detect
+repository state changes without requiring external dependencies like watchdog.
+
+Strategy: after a full scan, snapshot per-repo signatures. On each tick,
+recheck signatures cheaply (N os.stat calls). Only changed repos trigger a
+re-enrichment worker — no full rescan, no UI flicker.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:
+    from gitpulse.git_ops import RepoInfo
+except ImportError:
+    from git_ops import RepoInfo  # type: ignore[no-redef]
+
+
+def repo_signature(repo_path: Path) -> tuple[float, float, float]:
+    """Return (HEAD mtime, index mtime, refs/heads mtime) for *repo_path*.
+
+    Any unreadable path contributes 0.0 so the tuple is always well-typed.
+    Missing files won't cause false positives after the first stable snapshot.
+    """
+    def _mtime(p: Path) -> float:
+        try:
+            return os.stat(p).st_mtime
+        except OSError:
+            return 0.0
+
+    git_dir = repo_path / ".git"
+    return (
+        _mtime(git_dir / "HEAD"),
+        _mtime(git_dir / "index"),
+        _mtime(git_dir / "refs" / "heads"),
+    )
+
+
+def snapshot(repos: list[RepoInfo]) -> dict[Path, tuple[float, float, float]]:
+    """Build a path → signature map for all repos. O(N) stat calls."""
+    return {r.path: repo_signature(r.path) for r in repos}
+
+
+def changed_repos(
+    repos: list[RepoInfo],
+    previous: dict[Path, tuple[float, float, float]],
+) -> list[RepoInfo]:
+    """Return repos whose signature differs from *previous*.
+
+    A repo absent from *previous* is considered changed (first tick after
+    a new repo appears in the scan root).
+    """
+    changed: list[RepoInfo] = []
+    for repo in repos:
+        current_sig = repo_signature(repo.path)
+        if previous.get(repo.path) != current_sig:
+            changed.append(repo)
+    return changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "textual>=0.50.0",
     "rich>=13.0.0",
     "gitpython>=3.1.0",
+    "tomli>=2.0.0; python_version<'3.11'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Multi-repo fleet management — 6 Tier-S features                                                  
                                                                 
  Turn GitPulse from a one-repo dashboard into a fleet manager. You can now monitor, search, act on,  
  and clean up many repos at once instead of switching between them one by one.                       
                                                                                                      
  **+2,162 / −41 across 17 files · 15 commits**                                                       
                                                                                                      
  ---                                                                                                 
                                                                  
  ### What's new

  | Feature | What it does | Trigger |
  |---|---|---|
  | **Shared infra** | Parallel work helper, TOML config loader (`~/.config/gitpulse/config.toml`),
  named worker groups so scan/watch/bulk/digest don't block each other | — |                          
  | **Fleet Status bar** | 5 live chips at the top of the sidebar — `📁 total`, `🔴 dirty`, `⬆ ahead`,
   `⬇ behind`, `📦 stash` — updated as repos are scanned | — |                                        
  | **Watch mode** | `.git` mtime polling auto-refreshes any repo whose state changes; toggleable
  pause/resume with three visible indicators (toast, sidebar dot, header subtitle) | `w` |            
  | **Activity Digest** | Modal + CLI markdown summary of commits across all repos with `--since` and
  `--author` filters, aggregate insertions/deletions | `d` / `--digest` |                             
  | **Bulk ops** | Multi-select repos in the sidebar, run fetch/pull/push/etc across all of them via a
   command palette, with a per-repo results modal | `space` / `a` / `c` / `:` |                       
  | **Stale branches** | Modal listing branches older than a threshold, categorized (stale / very
  stale / abandoned), with last-commit metadata and bulk delete | `b` |                               
                                                                  
  ---                                                                                                                                                                                       
                                                                                                      
  ### Bugs fixed during testing                                                                       
   
  - `digest_screen.py` — malformed compound Rich closer `[/dim #color]` caused `MarkupError` and broke
   the digest modal render                                        
  - `tabs.py` (commits hints) — same compound-closer bug; Commits tab crashed on open                 
  - `tabs.py` (commit graph colorizer) — chained string replacements fed back into themselves, leaking
   visible markup like `*[[#3b4261]/[/]]` in the graph                                                
  - Watch toggle (`w`) had no visible effect because the search Input was auto-focused on startup;    
  keystroke went into the filter box instead of the binding                                           
                                                                  
  ---                                                                                                 
                                                                  
  ### Test plan

  Run `gitpulse --root ~/Workspace` and verify:                                                       
   
  - [ ] Sidebar lists repos; fleet chips show plausible counts (`🔴 dirty` matches repos with         
  uncommitted changes)                                            
  - [ ] `w` flips the live/paused state — toast appears, sidebar header shows `●live` / `○paused`,    
  header subtitle updates                                                                             
  - [ ] Touch a file in a watched repo — auto-refresh fires within ~5s; pause it and confirm it stops
  - [ ] `d` opens the digest modal cleanly; `gitpulse --digest --since 7d` emits valid markdown       
  - [ ] `space` selects repos, `a` selects all, `c` clears; `:` opens the action palette; running     
  `fetch` shows a per-repo results modal                                                              
  - [ ] `b` opens the stale-branches modal with categorized branches and last-commit metadata         
  - [ ] Click the **Commits** tab — graph renders without leaked markup                               
  - [ ] Resize terminal mid-session — no layout breakage                                              
  - [ ] `Ctrl+C` / `q` exits cleanly                                                                  
                                                                                                      
