### PR TITLE
feat(ui): Crimson Void dark-red theme overhaul

### DIFF
--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -711,8 +711,8 @@ def get_file_tree(path: Path) -> "rich.tree.Tree":
     # Render the dict structure into a Rich Tree
     repo_name = path.name
     rich_tree = RichTree(
-        f"[bold #7aa2f7]📁 {repo_name}[/]",
-        guide_style="#3b4261",
+        f"[bold #ff2d4a]📁 {repo_name}[/]",
+        guide_style="#2a2a3a",
     )
 
     def build_tree(node: "RichTree", d: dict) -> None:
@@ -721,22 +721,22 @@ def get_file_tree(path: Path) -> "rich.tree.Tree":
         files = sorted(k for k, v in d.items() if v is None)
 
         for name in dirs:
-            branch = node.add(f"[bold #bb9af7]📂 {name}[/]")
+            branch = node.add(f"[bold #e040fb]📂 {name}[/]")
             build_tree(branch, d[name])
 
         for name in files:
             # Color-code by extension
             ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
             if ext in ("py", "js", "ts", "go", "rs", "c", "cpp", "java"):
-                label = f"[#9ece6a]  {name}[/]"
+                label = f"[#3ddc84]  {name}[/]"
             elif ext in ("md", "rst", "txt"):
-                label = f"[#e0af68]  {name}[/]"
+                label = f"[#ffb74d]  {name}[/]"
             elif ext in ("json", "yaml", "yml", "toml", "ini", "cfg", "env"):
-                label = f"[#7dcfff]  {name}[/]"
+                label = f"[#4dd0e1]  {name}[/]"
             elif ext in ("sh", "bash", "zsh"):
-                label = f"[#f7768e]  {name}[/]"
+                label = f"[#ff5252]  {name}[/]"
             else:
-                label = f"[#c0caf5]  {name}[/]"
+                label = f"[#d4d4dc]  {name}[/]"
             node.add(label)
 
     build_tree(rich_tree, root_dict)

--- a/gitpulse/ui/bulk_results.py
+++ b/gitpulse/ui/bulk_results.py
@@ -30,14 +30,14 @@ class BulkResultsScreen(ModalScreen):
     #results-frame {
         width: 88%;
         height: 75%;
-        background: #1e2030;
-        border: thick #bb9af7;
+        background: #1a1a24;
+        border: thick #e040fb;
     }
     #results-title {
         dock: top;
         height: 1;
-        background: #24283b;
-        color: #bb9af7;
+        background: #242430;
+        color: #e040fb;
         text-style: bold;
         padding: 0 1;
     }
@@ -48,10 +48,10 @@ class BulkResultsScreen(ModalScreen):
     #results-footer {
         dock: bottom;
         height: 1;
-        background: #1e2030;
-        color: #565f89;
+        background: #1a1a24;
+        color: #555568;
         padding: 0 1;
-        border-top: solid #3b4261;
+        border-top: solid #2a2a3a;
     }
     """
 
@@ -87,13 +87,13 @@ class BulkResultsScreen(ModalScreen):
         self._completed += 1
 
         if isinstance(result, Exception):
-            status = "[bold #f7768e]ERROR[/]"
+            status = "[bold #ff5252]ERROR[/]"
             output = str(result)[:80]
         elif isinstance(result, str) and result.lower().startswith("error"):
-            status = "[bold #f7768e]FAIL[/]"
+            status = "[bold #ff5252]FAIL[/]"
             output = result[:80]
         else:
-            status = "[bold #9ece6a]OK[/]"
+            status = "[bold #3ddc84]OK[/]"
             output = (str(result) if result else "done")[:80]
 
         table.add_row(repo.name, status, output)

--- a/gitpulse/ui/command_palette.py
+++ b/gitpulse/ui/command_palette.py
@@ -39,19 +39,19 @@ class CommandPaletteModal(ModalScreen):
         height: auto;
         max-height: 24;
         padding: 1 2;
-        background: #1e2030;
-        border: thick #7aa2f7;
+        background: #1a1a24;
+        border: thick #ff2d4a;
     }
     #palette-title {
         text-style: bold;
-        color: #7aa2f7;
+        color: #ff2d4a;
         margin-bottom: 1;
         text-align: center;
         width: 100%;
         height: 1;
     }
     #palette-scope {
-        color: #e0af68;
+        color: #ffb74d;
         margin-bottom: 1;
         width: 100%;
         height: 1;
@@ -93,7 +93,7 @@ class CommandPaletteModal(ModalScreen):
         lv.clear()
         for key, label, desc in actions:
             lv.append(ListItem(
-                Static(f"[bold #9ece6a]{label}[/]  [dim #565f89]{desc}[/]", markup=True),
+                Static(f"[bold #3ddc84]{label}[/]  [dim #555568]{desc}[/]", markup=True),
                 id=f"action-{key}",
             ))
         if actions:
@@ -120,7 +120,6 @@ class CommandPaletteModal(ModalScreen):
         lv: ListView = self.query_one("#palette-list", ListView)
         item = lv.highlighted_child
         if item is None and self._filtered:
-            # If nothing highlighted but there's a match, pick first
             self._dispatch(self._filtered[0][0])
             return
         if item is not None and item.id and item.id.startswith("action-"):

--- a/gitpulse/ui/digest_screen.py
+++ b/gitpulse/ui/digest_screen.py
@@ -51,23 +51,23 @@ class DigestScreen(ModalScreen):
     #digest-frame {
         width: 95%;
         height: 90%;
-        background: #1e2030;
-        border: thick #7aa2f7;
+        background: #1a1a24;
+        border: thick #ff2d4a;
     }
     #digest-header {
         dock: top;
         height: 3;
-        background: #24283b;
-        color: #7aa2f7;
+        background: #242430;
+        color: #ff2d4a;
         text-style: bold;
         padding: 0 2;
-        border-bottom: heavy #3b4261;
+        border-bottom: heavy #2a2a3a;
         layout: horizontal;
         align: left middle;
     }
     #digest-window-label {
         width: auto;
-        color: #bb9af7;
+        color: #e040fb;
         margin-left: 2;
     }
     #digest-scroll {
@@ -81,10 +81,10 @@ class DigestScreen(ModalScreen):
     #digest-footer {
         dock: bottom;
         height: 1;
-        background: #1e2030;
-        color: #565f89;
+        background: #1a1a24;
+        color: #555568;
         padding: 0 1;
-        border-top: solid #3b4261;
+        border-top: solid #2a2a3a;
     }
     """
 
@@ -123,7 +123,7 @@ class DigestScreen(ModalScreen):
 
     def _load_digest(self) -> None:
         label: Static = self.query_one("#digest-window-label", Static)
-        label.update(f"[#bb9af7]window: {self._window}[/]")
+        label.update(f"[#e040fb]window: {self._window}[/]")
 
         body: Static = self.query_one("#digest-body", Static)
         body.update("[dim italic]Computing digest…[/]")
@@ -131,7 +131,7 @@ class DigestScreen(ModalScreen):
         try:
             since_ts = parse_since(self._window)
         except ValueError as e:
-            body.update(f"[bold #f7768e]Error: {e}[/]")
+            body.update(f"[bold #ff5252]Error: {e}[/]")
             return
 
         # Run in a worker so we don't block the UI
@@ -148,7 +148,7 @@ class DigestScreen(ModalScreen):
             self._render_digest()
         elif event.state == WorkerState.ERROR:
             body: Static = self.query_one("#digest-body", Static)
-            body.update(f"[bold #f7768e]Error building digest: {event.worker.error}[/]")
+            body.update(f"[bold #ff5252]Error building digest: {event.worker.error}[/]")
 
     def _render_digest(self) -> None:
         d = self._digest
@@ -160,34 +160,34 @@ class DigestScreen(ModalScreen):
         if d.total_commits == 0:
             body.update(
                 "[dim italic]  No commits found for this window and author pattern.[/]\n"
-                "[dim #565f89]  Tip: configure author emails in ~/.config/gitpulse/config.toml[/]"
+                "[dim #555568]  Tip: configure author emails in ~/.config/gitpulse/config.toml[/]"
             )
             return
 
         lines: list[str] = []
         since_str = datetime.fromtimestamp(d.since_ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
         lines.append(
-            f"[bold #7aa2f7]{d.total_commits}[/] commits across "
-            f"[bold #9ece6a]{d.repos_active}[/] repos  "
-            f"[#9ece6a]+{d.total_insertions}[/] [#f7768e]-{d.total_deletions}[/] lines  "
+            f"[bold #ff2d4a]{d.total_commits}[/] commits across "
+            f"[bold #3ddc84]{d.repos_active}[/] repos  "
+            f"[#3ddc84]+{d.total_insertions}[/] [#ff5252]-{d.total_deletions}[/] lines  "
             f"[dim]since {since_str} UTC[/]"
         )
-        lines.append("[dim #3b4261]─" * 60 + "[/]")
+        lines.append("[dim #2a2a3a]─" * 60 + "[/]")
 
         for rd in d.by_repo:
             lines.append(
-                f"\n[bold #bb9af7]📁 {rd.repo.name}[/]  "
+                f"\n[bold #e040fb]📁 {rd.repo.name}[/]  "
                 f"[dim]{len(rd.commits)} commit{'s' if len(rd.commits) != 1 else ''}  "
-                f"[#9ece6a]+{rd.insertions}[/]"
-                f" [#f7768e]-{rd.deletions}[/][/dim]"
+                f"[#3ddc84]+{rd.insertions}[/]"
+                f" [#ff5252]-{rd.deletions}[/][/dim]"
             )
             for c in rd.commits:
                 rel = relative_time(c.ts)
-                stats = f"[#9ece6a]+{c.insertions}[/] [#f7768e]-{c.deletions}[/]" if (c.insertions or c.deletions) else ""
+                stats = f"[#3ddc84]+{c.insertions}[/] [#ff5252]-{c.deletions}[/]" if (c.insertions or c.deletions) else ""
                 msg = c.message[:70]
                 lines.append(
-                    f"  [dim #7aa2f7]{c.short_hash}[/]  {msg}"
-                    f"  {stats}  [dim #565f89]{rel}[/]"
+                    f"  [dim #ff2d4a]{c.short_hash}[/]  {msg}"
+                    f"  {stats}  [dim #555568]{rel}[/]"
                 )
 
         body.update("\n".join(lines))

--- a/gitpulse/ui/fleet_status.py
+++ b/gitpulse/ui/fleet_status.py
@@ -31,7 +31,7 @@ class FleetChip(Static):
         content-align: center middle;
     }
     FleetChip:hover {
-        background: #283457;
+        background: #2d1520;
     }
     """
 
@@ -53,20 +53,21 @@ class FleetStatus(Widget):
     - ahead     — repos with unpushed commits
     - stashes   — total stash entries (sum)
     - stale     — repos with stale local branches
+    - all       — reset chip to clear any active filter
     """
 
     DEFAULT_CSS = """
     FleetStatus {
         height: 3;
-        background: #1e2030;
-        border-bottom: heavy #3b4261;
+        background: #1a1a24;
+        border-bottom: heavy #2a2a3a;
         layout: horizontal;
         align: left middle;
         padding: 0 1;
     }
     FleetStatus > Static#fleet-label {
         width: auto;
-        color: #565f89;
+        color: #555568;
         margin-right: 1;
     }
     """
@@ -85,13 +86,16 @@ class FleetStatus(Widget):
         yield FleetChip("ahead",   id="chip-ahead")
         yield FleetChip("stashes", id="chip-stashes")
         yield FleetChip("stale",   id="chip-stale")
+        yield FleetChip("all",     id="chip-all")
 
     def on_mount(self) -> None:
-        self._set_chip("chip-dirty",   "🔴", 0, "#f7768e")
-        self._set_chip("chip-behind",  "↓",  0, "#f7768e")
-        self._set_chip("chip-ahead",   "↑",  0, "#e0af68")
-        self._set_chip("chip-stashes", "📦", 0, "#7aa2f7")
-        self._set_chip("chip-stale",   "💀", 0, "#bb9af7")
+        self._set_chip("chip-dirty",   "◆ dirty",   0, "#ff5252")
+        self._set_chip("chip-behind",  "↓ behind",  0, "#ff5252")
+        self._set_chip("chip-ahead",   "↑ ahead",   0, "#ffb74d")
+        self._set_chip("chip-stashes", "⊞ stash",   0, "#4dd0e1")
+        self._set_chip("chip-stale",   "☠ stale",   0, "#e040fb")
+        chip: FleetChip = self.query_one("#chip-all", FleetChip)
+        chip.update("[dim #555568]· all[/]")
 
     def update_counters(self, repos: list[RepoInfo]) -> None:
         """Recompute all chips from the current repo list."""
@@ -101,15 +105,15 @@ class FleetStatus(Widget):
         total_stashes  = sum(r.stash_count for r in repos)
         n_stale        = sum(1 for r in repos if r.has_stale_branches)
 
-        self._set_chip("chip-dirty",   "🔴", n_dirty,       "#f7768e")
-        self._set_chip("chip-behind",  "↓",  total_behind,  "#f7768e")
-        self._set_chip("chip-ahead",   "↑",  n_ahead,       "#e0af68")
-        self._set_chip("chip-stashes", "📦", total_stashes, "#7aa2f7")
-        self._set_chip("chip-stale",   "💀", n_stale,       "#bb9af7")
+        self._set_chip("chip-dirty",   "◆ dirty",   n_dirty,       "#ff5252")
+        self._set_chip("chip-behind",  "↓ behind",  total_behind,  "#ff5252")
+        self._set_chip("chip-ahead",   "↑ ahead",   n_ahead,       "#ffb74d")
+        self._set_chip("chip-stashes", "⊞ stash",   total_stashes, "#4dd0e1")
+        self._set_chip("chip-stale",   "☠ stale",   n_stale,       "#e040fb")
 
-    def _set_chip(self, widget_id: str, icon: str, count: int, color: str) -> None:
+    def _set_chip(self, widget_id: str, label: str, count: int, color: str) -> None:
         chip: FleetChip = self.query_one(f"#{widget_id}", FleetChip)
         if count == 0:
-            chip.update(f"[dim #565f89]{icon} 0[/]")
+            chip.update(f"[dim #2a2a3a]{label}: 0[/]")
         else:
-            chip.update(f"[bold {color}]{icon} {count}[/]")
+            chip.update(f"[bold {color}]{label}: {count}[/]")

--- a/gitpulse/ui/sidebar.py
+++ b/gitpulse/ui/sidebar.py
@@ -31,13 +31,13 @@ def _make_badge(info: RepoInfo) -> str:
     """Build a Rich markup badge string with icon and optional file count."""
     count = info.modified_count
     if info.status == RepoStatus.CLEAN:
-        return "[bold white on #2d7d46] ✔ Clean [/]"
+        return "[bold #3ddc84 on #0f2a1a] ✔ Clean [/]"
     elif info.status == RepoStatus.MODIFIED:
-        label = f" ● Modified ({count}) " if count else " ● Modified "
-        return f"[bold #1a1b26 on #e0af68]{label}[/]"
+        label = f" ● {count} modified " if count else " ● Modified "
+        return f"[bold #ffb74d on #2a1e00]{label}[/]"
     else:  # UNTRACKED
-        label = f" ○ Untracked ({count}) " if count else " ○ Untracked "
-        return f"[bold white on #db4b4b]{label}[/]"
+        label = f" ○ {count} untracked " if count else " ○ Untracked "
+        return f"[bold #ff5252 on #2a0a0a]{label}[/]"
 
 
 # ---------------------------------------------------------------------------
@@ -49,12 +49,12 @@ _SPARK_CHARS = " ▁▂▃▄▅▆▇█"
 def _sparkline(activity: list[int]) -> str:
     """Build a 7-char sparkline from weekly commit counts (oldest→newest)."""
     if not activity or len(activity) < 7:
-        return "[dim #3b4261]▁▁▁▁▁▁▁[/]"
+        return "[dim #2a2a3a]▁▁▁▁▁▁▁[/]"
     mx = max(activity)
     if mx == 0:
-        return "[dim #3b4261]▁▁▁▁▁▁▁[/]"
+        return "[dim #2a2a3a]▁▁▁▁▁▁▁[/]"
     chars = "".join(_SPARK_CHARS[min(8, int(v / mx * 8))] for v in activity)
-    return f"[#7aa2f7]{chars}[/]"
+    return f"[#ff2d4a]{chars}[/]"
 
 
 # ---------------------------------------------------------------------------
@@ -88,24 +88,29 @@ class RepoListItem(ListItem):
 
         # Selection checkbox prefix
         if self._selected:
-            checkbox = "[bold #9ece6a][✓][/] "
+            checkbox = "[bold #3ddc84][✓][/] "
         else:
-            checkbox = "[dim #3b4261][ ][/] "
+            checkbox = "[dim #2a2a3a][ ][/] "
+
+        # Shorten path for display
+        path_str = str(info.path)
+        home = str(Path.home())
+        if path_str.startswith(home):
+            path_str = "~" + path_str[len(home):]
+        if len(path_str) > 38:
+            path_str = "…" + path_str[-37:]
 
         # Line 1: checkbox + repo name + badge
-        line1 = f"{checkbox}[bold #c0caf5]{info.name}[/]  {badge}"
+        line1 = f"{checkbox}[bold #d4d4dc]{info.name}[/]  {badge}"
         # Line 2: branch  |  relative time  |  sparkline
-        line2 = f"   [#bb9af7]⎇ {info.branch}[/]  [dim #565f89]⏱ {rel}[/]  {spark}"
+        line2 = f"   [#e040fb]⎇ {info.branch}[/]  [dim #555568]⏱ {rel}[/]  {spark}"
         # Line 3: truncated last commit message for quick context
         commit_msg = info.last_commit_msg
         if len(commit_msg) > 36:
             commit_msg = commit_msg[:35] + "…"
-        line3 = f"   [dim #565f89]💬 {commit_msg}[/]" if commit_msg else "   [dim #3b4261]no commits[/]"
+        line3 = f"   [dim #555568]💬 {commit_msg}[/]" if commit_msg else "   [dim #2a2a3a]no commits[/]"
         # Line 4: truncated repo path for disambiguation
-        path_str = str(info.path)
-        if len(path_str) > 38:
-            path_str = "…" + path_str[-37:]
-        line4 = f"   [dim #3b4261]{path_str}[/]"
+        line4 = f"   [dim #2a2a3a]{path_str}[/]"
 
         yield Static(f"{line1}\n{line2}\n{line3}\n{line4}", markup=True)
 
@@ -157,45 +162,33 @@ class RepoSidebar(Static):
             self._selected.discard(path)
         else:
             self._selected.add(path)
-        self._post_selection_changed()
+        self.post_message(self.SelectionChanged(
+            count=len(self._selected),
+            paths=list(self._selected),
+        ))
 
     def select_all_visible(self) -> None:
         for r in self._current_repos:
             self._selected.add(r.path)
-        self._post_selection_changed()
+        self.post_message(self.SelectionChanged(
+            count=len(self._selected),
+            paths=list(self._selected),
+        ))
         self.populate(self._current_repos)
 
     def clear_selection(self) -> None:
         self._selected.clear()
-        self._post_selection_changed()
+        self.post_message(self.SelectionChanged(count=0, paths=[]))
         self.populate(self._current_repos)
 
     def selected_repos(self) -> list[RepoInfo]:
         return [r for r in self._current_repos if r.path in self._selected]
 
-    def _post_selection_changed(self) -> None:
-        self.post_message(self.SelectionChanged(
-            count=len(self._selected),
-            paths=list(self._selected),
-        ))
-        # Update the header to show selection count
-        self._update_selection_indicator()
-
-    def _update_selection_indicator(self) -> None:
-        try:
-            title: Static = self.query_one("#sidebar-title", Static)
-            sel = len(self._selected)
-            if sel > 0:
-                # Append selection count to current title markup — regenerate
-                pass  # handled in update_header when called after populate
-        except Exception:
-            pass
-
     # ── Compose ─────────────────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
         yield Static(
-            "⚡ [bold #7aa2f7]GitPulse[/]",
+            "⚡ [bold #ff2d4a]GitPulse[/]",
             id="sidebar-title",
             markup=True,
         )
@@ -218,23 +211,23 @@ class RepoSidebar(Static):
         """
         title: Static = self.query_one("#sidebar-title", Static)
         if scanning:
-            title.update("⚡ [bold #7aa2f7]GitPulse[/]  [dim #565f89]scanning…[/]")
+            title.update("⚡ [bold #ff2d4a]GitPulse[/]  [dim #555568]scanning…[/]")
             return
         count_str = (
-            f"[dim #565f89]{count} repo{'s' if count != 1 else ''}[/]"
+            f"[dim #555568]{count} repo{'s' if count != 1 else ''}[/]"
             if count else ""
         )
         if live is True:
-            live_str = "  [bold #9ece6a]●live[/]"
+            live_str = "  [bold #3ddc84]●live[/]"
         elif live is False:
-            live_str = "  [dim #565f89]○paused[/]"
+            live_str = "  [dim #555568]○paused[/]"
         else:
             live_str = ""
 
         sel = len(self._selected)
-        sel_str = f"  [bold #e0af68][{sel} sel][/]" if sel > 0 else ""
+        sel_str = f"  [bold #ffb74d][{sel} sel][/]" if sel > 0 else ""
 
-        title.update(f"⚡ [bold #7aa2f7]GitPulse[/]{live_str}  {count_str}{sel_str}")
+        title.update(f"⚡ [bold #ff2d4a]GitPulse[/]{live_str}  {count_str}{sel_str}")
 
     def populate(self, repos: list[RepoInfo]) -> None:
         """Clear and re-populate the repo list."""
@@ -245,7 +238,7 @@ class RepoSidebar(Static):
         if not repos:
             from textual.widgets import ListItem as _LI
             list_view.append(_LI(Static(
-                "[dim italic #565f89]\n  📂  No repositories found\n"
+                "[dim italic #555568]\n  📂  No repositories found\n"
                 "      Try a different root or\n"
                 "      press r to rescan\n[/]",
                 markup=True,

--- a/gitpulse/ui/stale_screen.py
+++ b/gitpulse/ui/stale_screen.py
@@ -38,11 +38,11 @@ class DeleteConfirmModal(ModalScreen):
         width: 56;
         height: auto;
         padding: 1 2;
-        background: #1e2030;
-        border: thick #f7768e;
+        background: #1a1a24;
+        border: thick #ff5252;
     }
-    #dconf-title { color: #f7768e; text-style: bold; margin-bottom: 1; }
-    #dconf-info  { color: #e0af68; margin-bottom: 1; }
+    #dconf-title { color: #ff5252; text-style: bold; margin-bottom: 1; }
+    #dconf-info  { color: #ffb74d; margin-bottom: 1; }
     #dconf-input { width: 100%; margin-bottom: 1; }
     #dconf-btns  { layout: horizontal; width: 100%; height: 3; align: center middle; }
     """
@@ -101,14 +101,14 @@ class StaleScreen(ModalScreen):
     #stale-frame {
         width: 96%;
         height: 90%;
-        background: #1e2030;
-        border: thick #bb9af7;
+        background: #1a1a24;
+        border: thick #e040fb;
     }
     #stale-header {
         dock: top;
         height: 1;
-        background: #24283b;
-        color: #bb9af7;
+        background: #242430;
+        color: #e040fb;
         text-style: bold;
         padding: 0 1;
     }
@@ -116,10 +116,10 @@ class StaleScreen(ModalScreen):
     #stale-footer {
         dock: bottom;
         height: 1;
-        background: #1e2030;
-        color: #565f89;
+        background: #1a1a24;
+        color: #555568;
         padding: 0 1;
-        border-top: solid #3b4261;
+        border-top: solid #2a2a3a;
     }
     """
 
@@ -142,7 +142,7 @@ class StaleScreen(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with Container(id="stale-frame"):
-            yield Static(" 💀 Stale Branches", id="stale-header", markup=False)
+            yield Static(" ☠ Stale Branches", id="stale-header", markup=False)
             with TabbedContent(id="stale-tabs"):
                 for cat, label in [
                     ("stale",    f"Stale ({self._stale_weeks}w+)"),
@@ -170,7 +170,7 @@ class StaleScreen(ModalScreen):
 
     def _load_data(self) -> None:
         self.query_one("#stale-header", Static).update(
-            " 💀 Stale Branches  [dim #565f89]loading…[/]"
+            " ☠ Stale Branches  [dim #555568]loading…[/]"
         )
         self.run_worker(self._fetch_worker, thread=True, group="stale")
 
@@ -187,10 +187,10 @@ class StaleScreen(ModalScreen):
         if event.state == WorkerState.SUCCESS and event.worker.result is not None:
             self._categories = event.worker.result
             self._populate_tables()
-            self.query_one("#stale-header", Static).update(" 💀 Stale Branches")
+            self.query_one("#stale-header", Static).update(" ☠ Stale Branches")
         elif event.state == WorkerState.ERROR:
             self.query_one("#stale-header", Static).update(
-                f" 💀 Error: {event.worker.error}"
+                f" ☠ Error: {event.worker.error}"
             )
 
     def _populate_tables(self) -> None:
@@ -199,12 +199,12 @@ class StaleScreen(ModalScreen):
             table.clear()
             for b in sorted(branches, key=lambda x: x.age_days, reverse=True):
                 sel_key = (b.repo_name, b.name)
-                checkbox = "[bold #9ece6a]✓[/]" if sel_key in self._selected else "[ ]"
+                checkbox = "[bold #3ddc84]✓[/]" if sel_key in self._selected else "[ ]"
                 flags = []
-                if b.is_wip:            flags.append("[#e0af68]WIP[/]")
-                if b.is_merged_into_default: flags.append("[#9ece6a]merged[/]")
-                if b.is_current:        flags.append("[#7aa2f7]current[/]")
-                if not b.has_upstream:  flags.append("[dim]no-remote[/]")
+                if b.is_wip:                 flags.append("[#ffb74d]WIP[/]")
+                if b.is_merged_into_default: flags.append("[#3ddc84]merged[/]")
+                if b.is_current:             flags.append("[#ff2d4a]current[/]")
+                if not b.has_upstream:       flags.append("[dim]no-remote[/]")
                 flags_str = " ".join(flags) if flags else "[dim]—[/]"
                 age_str = f"{b.age_days}d"
                 msg = b.last_commit_msg[:40] + ("…" if len(b.last_commit_msg) > 40 else "")
@@ -256,7 +256,6 @@ class StaleScreen(ModalScreen):
         async def _after_confirm(confirmed: bool) -> None:
             if not confirmed:
                 return
-            # Collect BranchDetail objects for selected
             to_delete: list[BranchDetail] = []
             for cat_branches in self._categories.values():
                 for b in cat_branches:
@@ -274,7 +273,6 @@ class StaleScreen(ModalScreen):
 
             self._selected.clear()
             self._load_data()
-            self.app.post_message_no_wait = getattr(self.app, "post_message_no_wait", None)
 
         self.app.push_screen(DeleteConfirmModal(count=len(self._selected)), _after_confirm)
 

--- a/gitpulse/ui/styles.tcss
+++ b/gitpulse/ui/styles.tcss
@@ -1,12 +1,13 @@
 /* ===================================================================
    GitPulse — Textual CSS Styles
-   Dark Tokyo Night-inspired theme with premium feel.
+   "Crimson Void" dark red cyberpunk theme.
+   Primary accent: #ff2d4a  |  Backgrounds: near-black charcoals
    =================================================================== */
 
 /* ---------- Global ---------- */
 Screen {
-    background: #1a1b26;
-    color: #c0caf5;
+    background: #0a0a0f;
+    color: #d4d4dc;
 }
 
 /* ---------- Layout ---------- */
@@ -19,19 +20,19 @@ Screen {
     width: 46;
     min-width: 32;
     max-width: 58;
-    background: #16161e;
-    border-right: vkey #3b4261;
+    background: #12121a;
+    border-right: vkey #2a2a3a;
 }
 
 #sidebar-container {
     width: 100%;
     height: 1fr;
-    background: #16161e;
+    background: #12121a;
 }
 
 #main-panel {
     width: 1fr;
-    background: #1a1b26;
+    background: #0a0a0f;
 }
 
 /* ---------- Sidebar ---------- */
@@ -41,9 +42,9 @@ Screen {
     height: 3;
     content-align: center middle;
     text-style: bold;
-    color: #7aa2f7;
-    background: #1e2030;
-    border-bottom: heavy #3b4261;
+    color: #ff2d4a;
+    background: #1a1a24;
+    border-bottom: heavy #2a2a3a;
     padding: 0 1;
 }
 
@@ -54,128 +55,128 @@ Screen {
     height: 3;
     margin: 0;
     padding: 0 1;
-    background: #1e2030;
-    color: #c0caf5;
-    border-bottom: solid #3b4261;
+    background: #1a1a24;
+    color: #d4d4dc;
+    border-bottom: solid #2a2a3a;
 }
 
 #search-input:focus {
-    border-bottom: solid #7aa2f7;
+    border-bottom: solid #ff2d4a;
 }
 
 /* General input focus styling */
 Input:focus {
-    border: tall #7aa2f7;
+    border: tall #ff2d4a;
 }
 
 Input.-valid:focus {
-    border: tall #9ece6a;
+    border: tall #3ddc84;
 }
 
 #repo-list {
-    background: #16161e;
-    scrollbar-color: #3b4261;
-    scrollbar-color-hover: #7aa2f7;
-    scrollbar-color-active: #7aa2f7;
+    background: #12121a;
+    scrollbar-color: #2a2a3a;
+    scrollbar-color-hover: #ff2d4a;
+    scrollbar-color-active: #ff2d4a;
 }
 
 /* List item styling */
 RepoListItem {
-    background: #16161e;
+    background: #12121a;
     padding: 0 0 0 1;
     margin: 0;
-    border-bottom: solid #24283b;
+    border-bottom: solid #1e1e28;
 }
 
 RepoListItem:hover {
-    background: #1f2335;
+    background: #242430;
 }
 
 #repo-list:focus > RepoListItem.--highlight {
-    background: #283457;
+    background: #2d1520;
 }
 
 /* ---------- Main Panel / Tabs ---------- */
 TabbedContent {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: 1fr;
 }
 
 ContentSwitcher {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: 1fr;
 }
 
 TabPane {
-    background: #1a1b26;
+    background: #0a0a0f;
     padding: 1 2;
     height: 1fr;
 }
 
 Tabs {
-    background: #1e2030;
+    background: #1a1a24;
     dock: top;
     height: 3;
 }
 
 Tab {
-    color: #565f89;
-    background: #1e2030;
+    color: #555568;
+    background: #1a1a24;
     padding: 0 2;
     margin: 0 0;
 }
 
 Tab:hover {
-    color: #c0caf5;
-    background: #24283b;
+    color: #d4d4dc;
+    background: #242430;
 }
 
 Tab.-active {
-    color: #7aa2f7;
-    background: #1a1b26;
+    color: #ff2d4a;
+    background: #0a0a0f;
     text-style: bold;
 }
 
 Underline {
-    color: #7aa2f7;
+    color: #ff2d4a;
 }
 
 /* ---------- DataTable (Commits, Tags) ---------- */
 DataTable {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: 1fr;
 }
 
 DataTable > .datatable--header {
-    background: #1e2030;
-    color: #7aa2f7;
+    background: #1a1a24;
+    color: #ff2d4a;
     text-style: bold;
 }
 
 DataTable > .datatable--cursor {
-    background: #283457;
-    color: #c0caf5;
+    background: #2d1520;
+    color: #d4d4dc;
 }
 
 DataTable > .datatable--even-row {
-    background: #1a1b26;
+    background: #0a0a0f;
 }
 
 DataTable > .datatable--odd-row {
-    background: #1e2030;
+    background: #12121a;
 }
 
 /* ---------- Status / Diff / Remotes panels ---------- */
 #status-summary {
     height: auto;
-    background: #1a1b26;
+    background: #0a0a0f;
     padding: 0 1;
 }
 
 #status-file-list {
     height: 1fr;
-    background: #1a1b26;
-    scrollbar-color: #3b4261;
+    background: #0a0a0f;
+    scrollbar-color: #2a2a3a;
 }
 
 #status-hints,
@@ -186,25 +187,25 @@ DataTable > .datatable--odd-row {
 #tree-hints {
     height: 1;
     dock: bottom;
-    background: #1e2030;
-    color: #565f89;
+    background: #1a1a24;
+    color: #555568;
     padding: 0 1;
-    border-top: solid #3b4261;
+    border-top: solid #2a2a3a;
 }
 
 StatusFileItem {
     height: 1;
     padding: 0 1;
-    background: #1a1b26;
-    border-bottom: solid #1f2335;
+    background: #0a0a0f;
+    border-bottom: solid #12121a;
 }
 
 StatusFileItem:hover {
-    background: #1f2335;
+    background: #242430;
 }
 
 #status-file-list:focus > StatusFileItem.--highlight {
-    background: #283457;
+    background: #2d1520;
 }
 
 /* ---------- Diff tab layout ---------- */
@@ -216,48 +217,48 @@ StatusFileItem:hover {
 #diff-file-panel {
     width: 30;
     min-width: 22;
-    background: #16161e;
-    border-right: vkey #3b4261;
+    background: #12121a;
+    border-right: vkey #2a2a3a;
 }
 
 #diff-file-header {
     height: 1;
-    background: #1e2030;
+    background: #1a1a24;
     padding: 0 1;
-    color: #7aa2f7;
+    color: #ff2d4a;
     text-style: bold;
 }
 
 #diff-file-list {
     height: 1fr;
-    background: #16161e;
-    scrollbar-color: #3b4261;
+    background: #12121a;
+    scrollbar-color: #2a2a3a;
 }
 
 DiffFileItem {
     height: 1;
     padding: 0 1;
-    background: #16161e;
+    background: #12121a;
 }
 
 DiffFileItem:hover {
-    background: #1f2335;
+    background: #242430;
 }
 
 #diff-file-list:focus > DiffFileItem.--highlight {
-    background: #283457;
+    background: #2d1520;
 }
 
 #diff-view-panel {
     width: 1fr;
-    background: #1a1b26;
+    background: #0a0a0f;
     padding: 0 1;
     overflow-y: auto;
     overflow-x: auto;
 }
 
 #diff-content {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: auto;
 }
 
@@ -265,12 +266,12 @@ DiffFileItem:hover {
 #remotes-scroll {
     width: 100%;
     height: 1fr;
-    background: #1a1b26;
+    background: #0a0a0f;
     padding: 1 1;
 }
 
 #remotes-content {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: auto;
 }
 
@@ -283,8 +284,8 @@ DiffFileItem:hover {
 #commits-graph-scroll {
     width: 100%;
     height: 12;
-    background: #16161e;
-    border: solid #3b4261;
+    background: #12121a;
+    border: solid #2a2a3a;
     padding: 0 1;
     overflow-x: auto;
     overflow-y: auto;
@@ -292,90 +293,90 @@ DiffFileItem:hover {
 
 #commits-graph {
     height: auto;
-    background: #16161e;
+    background: #12121a;
 }
 
 /* ---------- Interactive file tree ---------- */
 #tree-widget {
     width: 100%;
     height: 1fr;
-    background: #1a1b26;
+    background: #0a0a0f;
     padding: 0 1;
 }
 
 Tree > .tree--guides {
-    color: #3b4261;
+    color: #2a2a3a;
 }
 
 Tree > .tree--guides-hover {
-    color: #7aa2f7;
+    color: #ff2d4a;
 }
 
 Tree > .tree--guides-selected {
-    color: #bb9af7;
+    color: #e040fb;
 }
 
 Tree > .tree--cursor {
-    background: #283457;
-    color: #c0caf5;
+    background: #2d1520;
+    color: #d4d4dc;
     text-style: bold;
 }
 
 Tree > .tree--highlight {
-    background: #1f2335;
+    background: #242430;
 }
 
 Tree > .tree--highlight-line {
-    color: #565f89;
+    color: #555568;
 }
 
 /* ---------- Branch list ---------- */
 #branch-list {
-    background: #1a1b26;
+    background: #0a0a0f;
     height: 1fr;
-    scrollbar-color: #3b4261;
-    scrollbar-color-hover: #7aa2f7;
-    scrollbar-color-active: #bb9af7;
+    scrollbar-color: #2a2a3a;
+    scrollbar-color-hover: #ff2d4a;
+    scrollbar-color-active: #e040fb;
 }
 
 BranchListItem {
     height: auto;
     padding: 0 1;
-    background: #1a1b26;
-    border-bottom: solid #24283b;
+    background: #0a0a0f;
+    border-bottom: solid #1e1e28;
 }
 
 BranchListItem:hover {
-    background: #1f2335;
+    background: #242430;
 }
 
 #branch-list:focus > BranchListItem.--highlight {
-    background: #283457;
+    background: #2d1520;
 }
 
 /* Branch list zebra-striping for better scanability */
 BranchListItem:even {
-    background: #1a1b26;
+    background: #0a0a0f;
 }
 
 BranchListItem:odd {
-    background: #1e2030;
+    background: #12121a;
 }
 
 /* ---------- Footer ---------- */
 Footer {
-    background: #1e2030;
-    color: #565f89;
+    background: #1a1a24;
+    color: #555568;
 }
 
 Footer > .footer--key {
-    color: #7aa2f7;
+    color: #ff2d4a;
     text-style: bold;
-    background: #24283b;
+    background: #2d1520;
 }
 
 Footer > .footer--description {
-    color: #a9b1d6;
+    color: #8888a0;
 }
 
 /* ---------- Buttons ---------- */
@@ -384,33 +385,33 @@ Button:focus {
 }
 
 Button.-primary:focus {
-    border: tall #7aa2f7;
+    border: tall #ff2d4a;
 }
 
 Button.-success:focus {
-    border: tall #9ece6a;
+    border: tall #3ddc84;
 }
 
 Button.-warning:focus {
-    border: tall #e0af68;
+    border: tall #ffb74d;
 }
 
 /* ---------- Header ---------- */
 Header {
-    background: #1e2030;
-    color: #7aa2f7;
+    background: #1a1a24;
+    color: #ff2d4a;
     dock: top;
     height: 1;
 }
 
 HeaderTitle {
-    color: #7aa2f7;
+    color: #ff2d4a;
     text-style: bold;
 }
 
 /* ---------- Empty state ---------- */
 .empty-message {
-    color: #565f89;
+    color: #555568;
     text-style: italic;
     padding: 2;
     content-align: center middle;
@@ -421,10 +422,38 @@ HeaderTitle {
 /* ---------- Scroll bars ---------- */
 * {
     scrollbar-size: 1 1;
-    scrollbar-color: #3b4261;
-    scrollbar-color-hover: #7aa2f7;
-    scrollbar-color-active: #7aa2f7;
-    scrollbar-background: #1a1b26;
-    scrollbar-background-hover: #1a1b26;
-    scrollbar-background-active: #1a1b26;
+    scrollbar-color: #2a2a3a;
+    scrollbar-color-hover: #ff2d4a;
+    scrollbar-color-active: #ff2d4a;
+    scrollbar-background: #0a0a0f;
+    scrollbar-background-hover: #0a0a0f;
+    scrollbar-background-active: #0a0a0f;
+}
+
+/* ---------- Fleet status bar ---------- */
+FleetStatus {
+    height: 3;
+    background: #1a1a24;
+    border-bottom: heavy #2a2a3a;
+    layout: horizontal;
+    align: left middle;
+    padding: 0 1;
+}
+
+FleetChip {
+    width: auto;
+    height: 1;
+    padding: 0 1;
+    margin: 0 1;
+    content-align: center middle;
+}
+
+FleetChip:hover {
+    background: #2d1520;
+}
+
+FleetChip.-active-filter {
+    background: #2d1520;
+    color: #ff2d4a;
+    text-style: bold;
 }

--- a/gitpulse/ui/tabs.py
+++ b/gitpulse/ui/tabs.py
@@ -90,19 +90,19 @@ class CommitModal(ModalScreen):
         width: 64;
         height: auto;
         padding: 1 2;
-        background: #1e2030;
-        border: thick #7aa2f7;
+        background: #1a1a24;
+        border: thick #ff2d4a;
     }
     #commit-title {
         text-style: bold;
-        color: #7aa2f7;
+        color: #ff2d4a;
         margin-bottom: 1;
         text-align: center;
         width: 100%;
         height: 1;
     }
     #commit-staged-info {
-        color: #9ece6a;
+        color: #3ddc84;
         margin-bottom: 1;
         width: 100%;
         height: auto;
@@ -131,7 +131,7 @@ class CommitModal(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with Container(id="commit-dialog"):
-            yield Static(" 󰄬  Commit Changes", id="commit-title", markup=False)
+            yield Static(" ✔  Commit Changes", id="commit-title", markup=False)
             n = len(self._staged_files)
             if n == 0:
                 info = "  No files staged. Use 's' or 'a' to stage first."
@@ -186,12 +186,12 @@ class NewBranchModal(ModalScreen):
         width: 52;
         height: auto;
         padding: 1 2;
-        background: #1e2030;
-        border: thick #bb9af7;
+        background: #1a1a24;
+        border: thick #e040fb;
     }
     #new-branch-title {
         text-style: bold;
-        color: #bb9af7;
+        color: #e040fb;
         margin-bottom: 1;
         text-align: center;
         width: 100%;
@@ -217,7 +217,7 @@ class NewBranchModal(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with Container(id="new-branch-dialog"):
-            yield Static("  New Branch", id="new-branch-title", markup=False)
+            yield Static("⎇  New Branch", id="new-branch-title", markup=False)
             yield Input(
                 placeholder="Branch name  (Enter to create · Esc to cancel)",
                 id="new-branch-input",
@@ -265,14 +265,14 @@ class CommitDiffModal(ModalScreen):
     #cdiff-frame {
         width: 92%;
         height: 88%;
-        background: #1e2030;
-        border: thick #7aa2f7;
+        background: #1a1a24;
+        border: thick #ff2d4a;
     }
     #cdiff-title {
         dock: top;
         height: 1;
-        background: #24283b;
-        color: #7aa2f7;
+        background: #242430;
+        color: #ff2d4a;
         text-style: bold;
         padding: 0 1;
     }
@@ -286,10 +286,10 @@ class CommitDiffModal(ModalScreen):
     #cdiff-footer {
         dock: bottom;
         height: 1;
-        background: #1e2030;
-        color: #565f89;
+        background: #1a1a24;
+        color: #555568;
         padding: 0 1;
-        border-top: solid #3b4261;
+        border-top: solid #2a2a3a;
     }
     """
 
@@ -341,12 +341,12 @@ class StashModal(ModalScreen):
         width: 56;
         height: auto;
         padding: 1 2;
-        background: #1e2030;
-        border: thick #e0af68;
+        background: #1a1a24;
+        border: thick #ffb74d;
     }
     #stash-title {
         text-style: bold;
-        color: #e0af68;
+        color: #ffb74d;
         margin-bottom: 1;
         text-align: center;
         width: 100%;
@@ -416,14 +416,14 @@ class FilePreviewModal(ModalScreen):
     #fpreview-frame {
         width: 92%;
         height: 88%;
-        background: #1e2030;
-        border: thick #9ece6a;
+        background: #1a1a24;
+        border: thick #3ddc84;
     }
     #fpreview-title {
         dock: top;
         height: 1;
-        background: #24283b;
-        color: #9ece6a;
+        background: #242430;
+        color: #3ddc84;
         text-style: bold;
         padding: 0 1;
     }
@@ -437,10 +437,10 @@ class FilePreviewModal(ModalScreen):
     #fpreview-footer {
         dock: bottom;
         height: 1;
-        background: #1e2030;
-        color: #565f89;
+        background: #1a1a24;
+        color: #555568;
         padding: 0 1;
-        border-top: solid #3b4261;
+        border-top: solid #2a2a3a;
     }
     """
 
@@ -509,9 +509,9 @@ class BranchListItem(ListItem):
 
     def compose(self) -> ComposeResult:
         if self.branch_info.is_current:
-            label = f"[bold #9ece6a]● {self.branch_info.name}[/]  [dim italic](current)[/]"
+            label = f"[bold #3ddc84]● {self.branch_info.name}[/]  [dim italic](current)[/]"
         else:
-            label = f"[#a9b1d6]  {self.branch_info.name}[/]"
+            label = f"[#d4d4dc]  {self.branch_info.name}[/]"
         yield Static(label, markup=True)
 
 
@@ -534,11 +534,11 @@ class DiffFileItem(ListItem):
         self.file_status = status  # "staged" | "unstaged" | "untracked"
         t = Text(overflow="ellipsis", no_wrap=True)
         if status == "staged":
-            t.append(f"+ {filepath}", style="bold #9ece6a")
+            t.append(f"+ {filepath}", style="bold #3ddc84")
         elif status == "unstaged":
-            t.append(f"~ {filepath}", style="#e0af68")
+            t.append(f"~ {filepath}", style="#ffb74d")
         else:
-            t.append(f"? {filepath}", style="dim #f7768e")
+            t.append(f"? {filepath}", style="dim #ff5252")
         super().__init__(Static(t), **kwargs)
 
 
@@ -561,14 +561,14 @@ class StatusFileItem(ListItem):
         self.file_status = status  # "staged" | "unstaged" | "untracked"
         t = Text(overflow="ellipsis", no_wrap=True)
         if status == "staged":
-            t.append("+ staged    ", style="bold #9ece6a")
-            t.append(filepath, style="#9ece6a")
+            t.append("+ staged    ", style="bold #3ddc84")
+            t.append(filepath, style="#3ddc84")
         elif status == "unstaged":
-            t.append("~ unstaged  ", style="#e0af68")
-            t.append(filepath, style="#e0af68")
+            t.append("~ unstaged  ", style="#ffb74d")
+            t.append(filepath, style="#ffb74d")
         else:
-            t.append("? untracked ", style="#f7768e")
-            t.append(filepath, style="#f7768e")
+            t.append("? untracked ", style="#ff5252")
+            t.append(filepath, style="#ff5252")
         super().__init__(Static(t), **kwargs)
 
 
@@ -642,7 +642,7 @@ class MainPanel(Widget):
                 )
                 yield ListView(id="status-file-list")
                 yield Static(
-                    "[dim #565f89]  s=stage  u=unstage  a=stage-all  U=unstage-all  c=commit  z=stash  Z=pop-stash[/]",
+                    f"[dim #555568]  s=stage  u=unstage  a=stage-all  U=unstage-all  c=commit  z=stash  Z=pop-stash[/]",
                     id="status-hints",
                     markup=True,
                 )
@@ -658,7 +658,7 @@ class MainPanel(Widget):
                         )
                     yield DataTable(id="commits-table")
                 yield Static(
-                    "[dim #565f89]  Enter or d = view commit diff[/]",
+                    "[dim #555568]  Enter or d = view commit diff[/]",
                     id="commits-hints",
                     markup=True,
                 )
@@ -668,7 +668,7 @@ class MainPanel(Widget):
                 with Horizontal(id="diff-layout"):
                     with Vertical(id="diff-file-panel"):
                         yield Static(
-                            "[bold #7aa2f7] Files[/]",
+                            "[bold #ff2d4a] Files[/]",
                             id="diff-file-header",
                             markup=True,
                         )
@@ -680,7 +680,7 @@ class MainPanel(Widget):
                             markup=True,
                         )
                 yield Static(
-                    "[dim #565f89]  + staged  ~ unstaged  ? untracked  ·  ↑↓ to navigate files[/]",
+                    "[dim #555568]  + staged  ~ unstaged  ? untracked  ·  ↑↓ to navigate files[/]",
                     id="diff-footer",
                     markup=True,
                 )
@@ -689,7 +689,7 @@ class MainPanel(Widget):
             with TabPane("🌿 Branches", id="tab-branches"):
                 yield ListView(id="branch-list")
                 yield Static(
-                    "[dim #565f89]  Enter=switch branch  n=new branch  d=delete branch[/]",
+                    "[dim #555568]  Enter=switch branch  n=new branch  d=delete branch[/]",
                     id="branch-hints",
                     markup=True,
                 )
@@ -703,7 +703,7 @@ class MainPanel(Widget):
                         markup=True,
                     )
                 yield Static(
-                    "[dim #565f89]  f=fetch  p=pull  P=push[/]",
+                    "[dim #555568]  f=fetch  p=pull  P=push[/]",
                     id="remotes-hints",
                     markup=True,
                 )
@@ -716,7 +716,7 @@ class MainPanel(Widget):
             with TabPane("🌲 Tree", id="tab-tree"):
                 yield Tree("🌲 Select a repository to browse files", id="tree-widget")
                 yield Static(
-                    "[dim #565f89]  ↑↓ navigate  Enter = preview file[/]",
+                    "[dim #555568]  ↑↓ navigate  Enter = preview file[/]",
                     id="tree-hints",
                     markup=True,
                 )
@@ -778,30 +778,30 @@ class MainPanel(Widget):
         stashes = get_stashes(repo_path)
 
         header = Text()
-        header.append("  Path:   ", style="bold #7aa2f7")
-        header.append(str(repo_path) + "\n", style="dim #565f89")
+        header.append("  Path:   ", style="bold #ff2d4a")
+        header.append(str(repo_path) + "\n", style="dim #555568")
         if info:
             rel = relative_time(info.last_commit_ts)
-            header.append("  Branch: ", style="bold #7aa2f7")
-            header.append(info.branch + "\n", style="#bb9af7")
-            header.append("  Commit: ", style="bold #7aa2f7")
+            header.append("  Branch: ", style="bold #ff2d4a")
+            header.append(info.branch + "\n", style="#e040fb")
+            header.append("  Commit: ", style="bold #ff2d4a")
             header.append(info.last_commit_msg, style="dim")
-            header.append(f"  ({rel})\n", style="dim #565f89")
-            header.append("  Stats:  ", style="bold #7aa2f7")
-            header.append(str(info.total_commits), style="#9ece6a")
+            header.append(f"  ({rel})\n", style="dim #555568")
+            header.append("  Stats:  ", style="bold #ff2d4a")
+            header.append(str(info.total_commits), style="#3ddc84")
             header.append(" commits · ")
-            header.append(str(info.contributor_count), style="#e0af68")
+            header.append(str(info.contributor_count), style="#ffb74d")
             n_contrib = info.contributor_count
             header.append(f" contributor{'s' if n_contrib != 1 else ''}")
         if stashes:
-            header.append(f"\n  Stashes: ", style="bold #7aa2f7")
-            header.append(str(len(stashes)), style="#7dcfff")
+            header.append(f"\n  Stashes: ", style="bold #ff2d4a")
+            header.append(str(len(stashes)), style="#4dd0e1")
             header.append(f" ({', '.join(s.message[:30] for s in stashes[:2])})", style="dim")
 
         summary_panel = Panel(
             header,
-            title=f"[bold #c0caf5] {repo_path.name} [/]",
-            border_style="#3b4261",
+            title=f"[bold #d4d4dc] {repo_path.name} [/]",
+            border_style="#2a2a3a",
             padding=(0, 0),
         )
         self.query_one("#status-summary", Static).update(summary_panel)
@@ -812,28 +812,28 @@ class MainPanel(Widget):
         if not fs.staged and not fs.unstaged and not fs.untracked:
             file_list.append(
                 ListItem(Static(
-                    "[bold #9ece6a]  ✨ Working tree clean — nothing to commit[/]",
+                    "[bold #3ddc84]  ✨ Working tree clean — nothing to commit[/]",
                     markup=True,
                 ))
             )
         else:
             if fs.staged:
                 file_list.append(ListItem(Static(
-                    f"[bold #9ece6a]  ✔ Staged[/] [dim #565f89]({len(fs.staged)} file{'s' if len(fs.staged) != 1 else ''})[/]",
+                    f"[bold #3ddc84]  ✔ Staged[/] [dim #555568]({len(fs.staged)} file{'s' if len(fs.staged) != 1 else ''})[/]",
                     markup=True,
                 )))
                 for f in fs.staged:
                     file_list.append(StatusFileItem(f, "staged"))
             if fs.unstaged:
                 file_list.append(ListItem(Static(
-                    f"[bold #e0af68]  ● Unstaged[/] [dim #565f89]({len(fs.unstaged)} file{'s' if len(fs.unstaged) != 1 else ''})[/]",
+                    f"[bold #ffb74d]  ● Unstaged[/] [dim #555568]({len(fs.unstaged)} file{'s' if len(fs.unstaged) != 1 else ''})[/]",
                     markup=True,
                 )))
                 for f in fs.unstaged:
                     file_list.append(StatusFileItem(f, "unstaged"))
             if fs.untracked:
                 file_list.append(ListItem(Static(
-                    f"[bold #f7768e]  ○ Untracked[/] [dim #565f89]({len(fs.untracked)} file{'s' if len(fs.untracked) != 1 else ''})[/]",
+                    f"[bold #ff5252]  ○ Untracked[/] [dim #555568]({len(fs.untracked)} file{'s' if len(fs.untracked) != 1 else ''})[/]",
                     markup=True,
                 )))
                 for f in fs.untracked:
@@ -862,14 +862,14 @@ class MainPanel(Widget):
                 )
                 tagged = re.sub(
                     r"\b([0-9a-f]{7})\b",
-                    r"[bold #7aa2f7]\1[/]",
+                    r"[bold #ff2d4a]\1[/]",
                     tagged,
                 )
                 tagged = (
-                    tagged.replace(STAR, "[#bb9af7]*[/]")
-                          .replace(PIPE, "[#3b4261]|[/]")
-                          .replace(SLASH, "[#3b4261]/[/]")
-                          .replace(BACK, "[#3b4261]\\\\[/]")
+                    tagged.replace(STAR, "[#e040fb]*[/]")
+                          .replace(PIPE, "[#2a2a3a]|[/]")
+                          .replace(SLASH, "[#2a2a3a]/[/]")
+                          .replace(BACK, "[#2a2a3a]\\\\[/]")
                 )
                 colored_lines.append(tagged)
             graph_static.update("\n".join(colored_lines))
@@ -887,17 +887,17 @@ class MainPanel(Widget):
         authors = len(set(c.author for c in commits))
         hints: Static = self.query_one("#commits-hints", Static)
         hints.update(
-            f"[dim #565f89]  {len(commits)} commits · "
-            f"[#9ece6a]+{total_ins}[/] / [#f7768e]-{total_del}[/] lines · "
+            f"[dim #555568]  {len(commits)} commits · "
+            f"[#3ddc84]+{total_ins}[/] / [#ff5252]-{total_del}[/] lines · "
             f"{total_files} files · {authors} author{'s' if authors != 1 else ''} · "
             f"Enter or d = view diff[/]"
         )
 
         for c in commits:
             pm = Text()
-            pm.append(f"+{c.insertions}", style="bold #9ece6a")
+            pm.append(f"+{c.insertions}", style="bold #3ddc84")
             pm.append(" ")
-            pm.append(f"-{c.deletions}", style="bold #f7768e")
+            pm.append(f"-{c.deletions}", style="bold #ff5252")
             table.add_row(
                 c.short_hash, c.author, c.date,
                 c.message[:60], str(c.files_changed), pm,
@@ -942,17 +942,17 @@ class MainPanel(Widget):
             lines.append("[dim italic]No remotes configured[/]")
         else:
             for r in remotes:
-                lines.append(f"[bold #7aa2f7]━━ {r.name} ━━[/]")
+                lines.append(f"[bold #ff2d4a]━━ {r.name} ━━[/]")
                 lines.append(f"  [bold]URL:[/]   [dim]{r.url}[/]")
                 if r.ahead or r.behind:
                     parts = []
                     if r.ahead:
-                        parts.append(f"[bold #9ece6a]↑ {r.ahead} ahead[/]")
+                        parts.append(f"[bold #3ddc84]↑ {r.ahead} ahead[/]")
                     if r.behind:
                         parts.append(f"[bold #f7768e]↓ {r.behind} behind[/]")
                     lines.append(f"  [bold]Sync:[/]  {' · '.join(parts)}")
                 else:
-                    lines.append("  [bold]Sync:[/]  [#9ece6a]✓ Up to date[/]")
+                    lines.append("  [bold]Sync:[/]  [#3ddc84]✓ Up to date[/]")
                 lines.append("")
         self.query_one("#remotes-content", Static).update("\n".join(lines))
 
@@ -970,7 +970,7 @@ class MainPanel(Widget):
         tree_widget: Tree = self.query_one("#tree-widget", Tree)
         tree_widget.clear()
         tree_widget.root.label = Text.from_markup(
-            f"[bold #7aa2f7]\U0001f4c1 {repo_path.name}[/]"
+            f"[bold #ff2d4a]\U0001f4c1 {repo_path.name}[/]"
         )
         tree_widget.root.expand()
 
@@ -1002,7 +1002,7 @@ class MainPanel(Widget):
             files = sorted(k for k, v in d.items() if v is None)
             for name in dirs:
                 child = node.add(
-                    f"[bold #bb9af7]\ud83d\udcc2 {name}[/]",
+                    f"[bold #e040fb]\ud83d\udcc2 {name}[/]",
                     data={"type": "dir"},
                 )
                 _build(child, d[name], f"{prefix}{name}/")
@@ -1021,15 +1021,15 @@ class MainPanel(Widget):
                 }
                 icon = _FILE_ICONS.get(ext, "📄")
                 if ext in ("py", "js", "ts", "go", "rs", "c", "cpp", "java"):
-                    label = f"[#9ece6a]{icon} {name}[/]"
+                    label = f"[#3ddc84]{icon} {name}[/]"
                 elif ext in ("md", "rst", "txt"):
-                    label = f"[#e0af68]{icon} {name}[/]"
+                    label = f"[#ffb74d]{icon} {name}[/]"
                 elif ext in ("json", "yaml", "yml", "toml", "ini", "cfg", "env"):
-                    label = f"[#7dcfff]{icon} {name}[/]"
+                    label = f"[#4dd0e1]{icon} {name}[/]"
                 elif ext in ("sh", "bash", "zsh"):
                     label = f"[#f7768e]{icon} {name}[/]"
                 else:
-                    label = f"[#c0caf5]{icon} {name}[/]"
+                    label = f"[#d4d4dc]{icon} {name}[/]"
                 node.add_leaf(
                     label,
                     data={"type": "file", "path": f"{prefix}{name}"},

--- a/gitpulse/utils.py
+++ b/gitpulse/utils.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone, timedelta
 # Package version — single source of truth
 # ---------------------------------------------------------------------------
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Complete visual redesign from Tokyo Night to 'Crimson Void' dark-red cyberpunk theme across all 10 UI files.

Color palette:
- Background: near-black charcoals (#0a0a0f → #242430)
- Primary accent: #ff2d4a (cyberpunk red) for focus/active/branding
- Semantic: green #3ddc84, amber #ffb74d, red #ff5252, cyan #4dd0e1
- Branch names: magenta #e040fb

Changes:
- styles.tcss: full rewrite — tabs, footer, fleet chips, scrollbars, DataTable, Tree, ListView, all panels themed
- sidebar.py: red branding, colored badges, magenta branches, red sparklines, ~/  path shortening, dead code removed
- fleet_status.py: new chip colors + 'all' reset chip + clearer labels
- tabs.py: all 5 modals updated; commit graph uses red hashes and magenta graph nodes; file tree, remotes, hints bars all updated; Nerd Font icons replaced with safe Unicode
- command_palette.py: red border/title, green actions
- bulk_results.py: magenta border, green OK, red ERROR
- digest_screen.py: red border, magenta repo names, green/red stats
- stale_screen.py: magenta border, dead code removed
- git_ops.py: file tree colors updated to match palette
- utils.py: version bumped 1.2.0 → 1.2.1 (sync with pyproject.toml)

Zero legacy Tokyo Night color tokens remain.