### PR TITLE
chore: publish GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,13 @@ jobs:
         run: |
           git tag -a "v${{ env.NEW_VERSION }}" -m "v${{ env.NEW_VERSION }}"
           git push origin "v${{ env.NEW_VERSION }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "v${{ env.NEW_VERSION }}"
+          name: "v${{ env.NEW_VERSION }}"
+          generate_release_notes: true
           
       - name: Build package
         run: python -m build


### PR DESCRIPTION
## Summary
Publish a GitHub Release automatically for each version bump by using the newly created `vX.Y.Z` tag. PyPI publishing stays unchanged.

## Changes
- Create a GitHub Release from the `vNEW_VERSION` tag with auto-generated notes.

## Impact
- Releases are now published automatically and stay in sync with the package version.

## Testing
- Not applicable (workflow change only).