### PR TITLE
feat: add npm distribution wrapper for GitPulse

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Build and Publish to PyPI
+name: Build and Publish
 
 on:
   push:
@@ -12,39 +12,42 @@ jobs:
       contents: write
     # Prevent infinite loop if the commit is from the bot itself
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    
+    outputs:
+      new_version: ${{ steps.bump.outputs.NEW_VERSION }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           # A personal access token or the default GITHUB_TOKEN is required to push back
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build twine
-          
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
+
       - name: Bump version
         id: bump
         run: |
           NEW_VERSION=$(python scripts/bump_version.py)
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Successfully bumped version to $NEW_VERSION"
-          
+
       - name: Commit version bump
         run: |
-          git add pyproject.toml gitpulse/utils.py
+          git add pyproject.toml gitpulse/utils.py npm/package.json
           git commit -m "chore: bump version to ${{ env.NEW_VERSION }} [skip ci]"
           git push origin main
 
@@ -59,11 +62,55 @@ jobs:
           tag_name: "v${{ env.NEW_VERSION }}"
           name: "v${{ env.NEW_VERSION }}"
           generate_release_notes: true
-          
+
       - name: Build package
         run: python -m build
-        
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          # The tag created by build-and-publish carries the bumped npm/package.json
+          ref: "v${{ needs.build-and-publish.outputs.new_version }}"
+
+      - name: Wait for PyPI to publish the pinned version
+        # The npm postinstall installs gitpulse-tui==<version>; make sure that
+        # exact version is queryable on PyPI before npm goes live, so a fresh
+        # `npm install -g gitpulse` cannot race ahead of PyPI propagation.
+        run: |
+          VERSION="${{ needs.build-and-publish.outputs.new_version }}"
+          URL="https://pypi.org/pypi/gitpulse-tui/${VERSION}/json"
+          echo "Waiting for ${URL} ..."
+          for i in $(seq 1 60); do
+            CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+            if [ "$CODE" = "200" ]; then
+              echo "gitpulse-tui==${VERSION} is live on PyPI."
+              exit 0
+            fi
+            echo "  attempt $i: HTTP $CODE — retrying in 10s"
+            sleep 10
+          done
+          echo "Timed out waiting for gitpulse-tui==${VERSION} on PyPI."
+          exit 1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        working-directory: npm
+        # No `npm install` first — the wrapper has zero dependencies, and
+        # skipping it avoids running the Python-bootstrapping postinstall in CI.
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ pip install gitpulse-tui
 ```
 *(We recommend using `pipx install gitpulse-tui` to install it in an isolated environment)*
 
+### Install via npm
+
+GitPulse is also available as an npm package. The npm package is a thin
+launcher — it bootstraps an isolated Python environment and runs the same
+Python application (no logic is duplicated):
+
+```bash
+npm install -g gitpulse
+```
+
+This requires Python 3.10+ on your system; the wrapper handles the rest.
+See [npm/README.md](./npm/README.md) for details and troubleshooting.
+
 ### Install from source
 
 If you prefer to install from source or want to contribute to the project:

--- a/npm/LICENSE
+++ b/npm/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,90 @@
+# ⚡ gitpulse (npm)
+
+npm launcher for **GitPulse** — a developer-focused terminal dashboard that
+scans a directory for local Git repositories and shows live status, commits,
+diffs, branches, and more.
+
+This npm package is a **thin wrapper**. The application itself is written in
+Python and published to PyPI as [`gitpulse-tui`](https://pypi.org/project/gitpulse-tui/).
+Installing via npm simply bootstraps an isolated Python environment and launches
+that package — there is no duplicated logic, and Python remains the single
+source of truth.
+
+## Install
+
+```bash
+npm install -g gitpulse
+```
+
+On install, the wrapper:
+
+1. Detects a host Python 3.10+ interpreter.
+2. Creates an isolated virtual environment at `~/.gitpulse/venv`.
+3. Installs the matching `gitpulse-tui` version from PyPI into it.
+
+Then just run:
+
+```bash
+gitpulse                          # scan the current directory
+gitpulse --root /path/to/repos    # scan a custom directory
+gitpulse --commits 20             # show 20 commits per repo
+gitpulse --digest --since 7d      # print an activity digest
+gitpulse --version
+```
+
+All arguments are forwarded transparently to the Python CLI.
+
+## Requirements
+
+- **Node.js** ≥ 16 (for the launcher only)
+- **Python** ≥ 3.10 (the application runtime)
+- **git** available on `PATH`
+- Linux or macOS (Windows is best-effort)
+
+## How it works
+
+```
+npm install -g gitpulse
+   └─ postinstall → ~/.gitpulse/venv → pip install gitpulse-tui==<version>
+
+gitpulse <args>
+   └─ bin/gitpulse.js → spawn <venv>/python -m gitpulse <args>   (stdio inherited)
+```
+
+The npm and PyPI versions are kept in lockstep by CI: npm `vX.Y.Z` always
+installs `gitpulse-tui==X.Y.Z`.
+
+If the npm `postinstall` step cannot complete (e.g. offline), it does **not**
+fail the install — the launcher automatically retries the setup the first time
+you run `gitpulse`.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `GITPULSE_FORCE_REINSTALL=1` | Rebuild the `~/.gitpulse/venv` from scratch before launching |
+| `GITPULSE_SKIP_POSTINSTALL=1` | Skip the Python bootstrap during `npm install` (CI/Docker) |
+
+## Troubleshooting
+
+**`The Python 'venv' module is unavailable`** (Debian/Ubuntu)
+
+```bash
+sudo apt install python3-venv
+GITPULSE_FORCE_REINSTALL=1 gitpulse --version
+```
+
+**`Python 3.10 or newer ... not found`**
+
+Install Python 3.10+ from <https://www.python.org/downloads/>, then re-run
+`npm install -g gitpulse`.
+
+**The environment looks broken**
+
+```bash
+GITPULSE_FORCE_REINSTALL=1 gitpulse --version
+```
+
+## License
+
+AGPL-3.0 — see [LICENSE](./LICENSE).

--- a/npm/bin/gitpulse.js
+++ b/npm/bin/gitpulse.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * gitpulse.js — npm launcher for the Python GitPulse TUI.
+ *
+ * This is a thin wrapper: it ensures the version-pinned Python package is
+ * installed in an isolated venv, then hands off entirely to it. All command
+ * line arguments are forwarded transparently and stdin/stdout/stderr are
+ * inherited so the Textual TUI works exactly as it does under pip.
+ *
+ * Wrapper behaviour is controlled only via environment variables, never CLI
+ * flags, so argument forwarding to Python stays 100% transparent:
+ *   GITPULSE_FORCE_REINSTALL=1   rebuild the venv before launching
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { spawn } = require("child_process");
+
+const { ensurePythonPackage, InstallError } = require("../lib/install");
+const { venvPython, stateFile } = require("../lib/paths");
+
+const pkg = require(path.join(__dirname, "..", "package.json"));
+const TARGET_VERSION = pkg.version;
+
+function fail(message, code) {
+  process.stderr.write(`\ngitpulse: ${message}\n\n`);
+  process.exit(code || 1);
+}
+
+/** True when the venv already matches the version this launcher expects. */
+function venvIsCurrent() {
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(stateFile(), "utf8"));
+  } catch (_) {
+    return false;
+  }
+  if (!state || state.installedVersion !== TARGET_VERSION) {
+    return false;
+  }
+  try {
+    fs.accessSync(venvPython(), fs.constants.X_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/** Ensure the Python package is installed; returns the venv interpreter path. */
+function prepareInterpreter() {
+  const force = process.env.GITPULSE_FORCE_REINSTALL === "1";
+  if (!force && venvIsCurrent()) {
+    return venvPython();
+  }
+  try {
+    return ensurePythonPackage({ targetVersion: TARGET_VERSION, force });
+  } catch (err) {
+    if (err instanceof InstallError) {
+      fail(`could not prepare the Python runtime.\n\n${err.message}`, 1);
+    }
+    fail(`unexpected error preparing the Python runtime: ${err}`, 1);
+  }
+  return venvPython();
+}
+
+function main() {
+  const interpreter = prepareInterpreter();
+  const args = ["-m", "gitpulse"].concat(process.argv.slice(2));
+
+  const child = spawn(interpreter, args, { stdio: "inherit" });
+
+  // Forward termination signals so Ctrl+C / kill reaches the TUI cleanly.
+  const forward = (signal) => {
+    if (!child.killed) {
+      try {
+        child.kill(signal);
+      } catch (_) {
+        /* child already gone */
+      }
+    }
+  };
+  process.on("SIGINT", () => forward("SIGINT"));
+  process.on("SIGTERM", () => forward("SIGTERM"));
+
+  child.on("error", (err) => {
+    if (err && err.code === "ENOENT") {
+      fail(
+        "the Python environment appears to be broken.\n" +
+          "Rebuild it with:  GITPULSE_FORCE_REINSTALL=1 gitpulse --version",
+        1,
+      );
+    }
+    fail(`failed to launch GitPulse: ${err.message || err}`, 1);
+  });
+
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      // Mirror POSIX convention: 128 + signal number.
+      const signals = { SIGINT: 2, SIGTERM: 15, SIGHUP: 1, SIGQUIT: 3 };
+      process.exit(128 + (signals[signal] || 0));
+    }
+    process.exit(code == null ? 1 : code);
+  });
+}
+
+main();

--- a/npm/lib/install.js
+++ b/npm/lib/install.js
@@ -1,0 +1,189 @@
+"use strict";
+
+/**
+ * install.js — Idempotent Python venv bootstrapper for the GitPulse npm wrapper.
+ *
+ * Creates an isolated virtual environment at ~/.gitpulse/venv and installs the
+ * version-pinned `gitpulse-tui` package from PyPI into it. The npm package
+ * carries no Python logic — it only orchestrates this install and then launches
+ * the Python entry point.
+ */
+
+const fs = require("fs");
+const { spawnSync } = require("child_process");
+
+const { findPython, pythonMissingMessage } = require("./python");
+const { gitpulseDir, venvDir, venvPython, stateFile } = require("./paths");
+
+const PYPI_PACKAGE = "gitpulse-tui";
+
+/** Error subclass carrying a pre-formatted, user-facing remediation message. */
+class InstallError extends Error {}
+
+function log(line) {
+  process.stdout.write(`${line}\n`);
+}
+
+function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(stateFile(), "utf8"));
+  } catch (_) {
+    return null;
+  }
+}
+
+function writeState(version, pythonPath) {
+  fs.writeFileSync(
+    stateFile(),
+    JSON.stringify(
+      {
+        installedVersion: version,
+        pythonPath: pythonPath,
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+/** True if the venv interpreter exists and is usable. */
+function venvPythonExists() {
+  try {
+    fs.accessSync(venvPython(), fs.constants.X_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/** Inspect a failed spawn result and throw an InstallError with guidance. */
+function throwForFailure(stage, result, targetVersion) {
+  const stderr = (result && result.stderr ? result.stderr : "").toString();
+  const stdout = (result && result.stdout ? result.stdout : "").toString();
+  const combined = `${stdout}\n${stderr}`;
+  let hint;
+
+  if (/No module named (venv|ensurepip)|ensurepip is not available/i.test(combined)) {
+    hint =
+      "The Python 'venv' module is unavailable.\n" +
+      "  Debian/Ubuntu:  sudo apt install python3-venv\n" +
+      "  Fedora:         sudo dnf install python3-venv";
+  } else if (
+    new RegExp(`No matching distribution.*${PYPI_PACKAGE}`, "i").test(combined) ||
+    /Could not find a version that satisfies/i.test(combined)
+  ) {
+    hint =
+      `gitpulse-tui==${targetVersion} was not found on PyPI yet.\n` +
+      "  A new release can take a minute to propagate — retry shortly with:\n" +
+      "    GITPULSE_FORCE_REINSTALL=1 gitpulse";
+  } else if (
+    /Could not (fetch URL|connect)|Network is unreachable|Temporary failure in name resolution|timed out|SSLError|ProxyError/i.test(
+      combined,
+    )
+  ) {
+    hint =
+      "A network error occurred while contacting PyPI.\n" +
+      "  Check your internet connection / proxy settings and retry:\n" +
+      "    GITPULSE_FORCE_REINSTALL=1 gitpulse";
+  } else if (/Permission denied|EACCES/i.test(combined)) {
+    hint =
+      `Permission was denied while writing to ${gitpulseDir()}.\n` +
+      "  Ensure your user owns that directory and retry.";
+  } else {
+    hint = "Re-run with GITPULSE_FORCE_REINSTALL=1 to rebuild from scratch.";
+  }
+
+  const detail = stderr.trim() || stdout.trim() || "(no output captured)";
+  throw new InstallError(
+    `GitPulse setup failed during: ${stage}\n\n${hint}\n\n--- captured output ---\n${detail}`,
+  );
+}
+
+/** Remove a possibly-corrupt venv directory so it can be rebuilt. */
+function removeVenv() {
+  try {
+    fs.rmSync(venvDir(), { recursive: true, force: true });
+  } catch (_) {
+    /* best effort */
+  }
+}
+
+/**
+ * Ensure the version-pinned Python GitPulse package is installed in the venv.
+ *
+ * @param {object} opts
+ * @param {string} opts.targetVersion  Exact version to pin (e.g. "1.2.2").
+ * @param {boolean} [opts.force]       Rebuild even if state looks current.
+ * @returns {string} Absolute path to the venv Python interpreter.
+ */
+function ensurePythonPackage(opts) {
+  const targetVersion = opts.targetVersion;
+  const force = Boolean(opts.force);
+
+  // Fast path — already on the right version.
+  if (!force) {
+    const state = readState();
+    if (state && state.installedVersion === targetVersion && venvPythonExists()) {
+      return venvPython();
+    }
+  }
+
+  // Locate a host interpreter to bootstrap the venv.
+  const python = findPython();
+  if (!python) {
+    throw new InstallError(pythonMissingMessage());
+  }
+  log(`▸ Using Python ${python.version} (${python.command})`);
+
+  fs.mkdirSync(gitpulseDir(), { recursive: true });
+
+  // Create (or recreate) the venv.
+  if (force) {
+    removeVenv();
+  }
+  if (!venvPythonExists()) {
+    log("▸ Creating isolated environment at ~/.gitpulse/venv …");
+    const venvArgs = python.args.concat(["-m", "venv", venvDir()]);
+    const venvResult = spawnSync(python.command, venvArgs, {
+      encoding: "utf8",
+      timeout: 120000,
+    });
+    if (!venvResult || venvResult.status !== 0) {
+      removeVenv();
+      throwForFailure("creating virtual environment", venvResult, targetVersion);
+    }
+    log("  ✓ Environment created");
+  }
+
+  // Upgrade pip (best-effort — uses the latest pip for reliability).
+  log("▸ Upgrading pip …");
+  const pipUpgrade = spawnSync(
+    venvPython(),
+    ["-m", "pip", "install", "--upgrade", "pip"],
+    { encoding: "utf8", timeout: 180000 },
+  );
+  if (!pipUpgrade || pipUpgrade.status !== 0) {
+    log("  ! pip upgrade skipped (non-fatal) — continuing");
+  } else {
+    log("  ✓ pip up to date");
+  }
+
+  // Install the exact-pinned GitPulse package.
+  const spec = `${PYPI_PACKAGE}==${targetVersion}`;
+  log(`▸ Installing ${spec} from PyPI …`);
+  const install = spawnSync(
+    venvPython(),
+    ["-m", "pip", "install", "--upgrade", spec],
+    { encoding: "utf8", timeout: 300000 },
+  );
+  if (!install || install.status !== 0) {
+    throwForFailure(`installing ${spec}`, install, targetVersion);
+  }
+  log(`  ✓ Installed ${spec}`);
+
+  writeState(targetVersion, venvPython());
+  return venvPython();
+}
+
+module.exports = { ensurePythonPackage, InstallError, PYPI_PACKAGE };

--- a/npm/lib/paths.js
+++ b/npm/lib/paths.js
@@ -1,0 +1,40 @@
+"use strict";
+
+/**
+ * paths.js — Cross-platform path helpers for the GitPulse npm wrapper.
+ *
+ * All runtime state lives in a stable per-user directory (~/.gitpulse) so it
+ * survives npm package upgrades and avoids permission issues with global
+ * node_modules locations.
+ */
+
+const os = require("os");
+const path = require("path");
+
+/** Root directory for all npm-wrapper-managed GitPulse state. */
+function gitpulseDir() {
+  return path.join(os.homedir(), ".gitpulse");
+}
+
+/** Directory holding the isolated Python virtual environment. */
+function venvDir() {
+  return path.join(gitpulseDir(), "venv");
+}
+
+/**
+ * Absolute path to the Python interpreter inside the venv.
+ * Windows venvs use Scripts/python.exe; POSIX venvs use bin/python.
+ */
+function venvPython() {
+  if (process.platform === "win32") {
+    return path.join(venvDir(), "Scripts", "python.exe");
+  }
+  return path.join(venvDir(), "bin", "python");
+}
+
+/** JSON file recording the installed version + interpreter path. */
+function stateFile() {
+  return path.join(gitpulseDir(), "state.json");
+}
+
+module.exports = { gitpulseDir, venvDir, venvPython, stateFile };

--- a/npm/lib/python.js
+++ b/npm/lib/python.js
@@ -1,0 +1,101 @@
+"use strict";
+
+/**
+ * python.js — Host Python interpreter detection for the GitPulse npm wrapper.
+ *
+ * Probes the common interpreter names and returns the first one that satisfies
+ * GitPulse's minimum requirement of Python 3.10+.
+ */
+
+const { spawnSync } = require("child_process");
+
+const MIN_MAJOR = 3;
+const MIN_MINOR = 10;
+
+// Probe candidates in priority order. `py -3` is the Windows launcher.
+function candidates() {
+  if (process.platform === "win32") {
+    return [
+      { command: "py", args: ["-3"] },
+      { command: "python", args: [] },
+      { command: "python3", args: [] },
+    ];
+  }
+  return [
+    { command: "python3", args: [] },
+    { command: "python", args: [] },
+  ];
+}
+
+/**
+ * Run `<candidate> -c "<print version>"` and parse "MAJOR MINOR".
+ * Returns { major, minor } or null if the candidate is unusable.
+ */
+function probeVersion(candidate) {
+  const probeArgs = candidate.args.concat([
+    "-c",
+    "import sys; print(sys.version_info[0], sys.version_info[1])",
+  ]);
+  let result;
+  try {
+    result = spawnSync(candidate.command, probeArgs, {
+      encoding: "utf8",
+      timeout: 15000,
+    });
+  } catch (_) {
+    return null;
+  }
+  if (!result || result.status !== 0 || !result.stdout) {
+    return null;
+  }
+  const parts = result.stdout.trim().split(/\s+/);
+  if (parts.length < 2) {
+    return null;
+  }
+  const major = parseInt(parts[0], 10);
+  const minor = parseInt(parts[1], 10);
+  if (Number.isNaN(major) || Number.isNaN(minor)) {
+    return null;
+  }
+  return { major, minor };
+}
+
+function meetsMinimum(version) {
+  if (version.major > MIN_MAJOR) return true;
+  return version.major === MIN_MAJOR && version.minor >= MIN_MINOR;
+}
+
+/**
+ * Find a usable Python interpreter.
+ *
+ * Returns { command, args, version: "X.Y" } for the first candidate that is
+ * Python 3.10+, or null if none qualifies.
+ */
+function findPython() {
+  for (const candidate of candidates()) {
+    const version = probeVersion(candidate);
+    if (version && meetsMinimum(version)) {
+      return {
+        command: candidate.command,
+        args: candidate.args,
+        version: `${version.major}.${version.minor}`,
+      };
+    }
+  }
+  return null;
+}
+
+/** Human-readable error shown when no suitable interpreter is found. */
+function pythonMissingMessage() {
+  return [
+    `GitPulse requires Python ${MIN_MAJOR}.${MIN_MINOR} or newer, but no`,
+    "suitable interpreter was found on your PATH.",
+    "",
+    "  Install Python 3.10+ from https://www.python.org/downloads/",
+    "  (Linux: use your package manager, e.g. `sudo apt install python3`)",
+    "",
+    "Then re-run:  npm install -g gitpulse",
+  ].join("\n");
+}
+
+module.exports = { findPython, pythonMissingMessage, MIN_MAJOR, MIN_MINOR };

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "gitpulse",
+  "version": "1.2.2",
+  "description": "Git Repo Dashboard TUI — npm launcher for the Python GitPulse package (gitpulse-tui on PyPI)",
+  "bin": {
+    "gitpulse": "bin/gitpulse.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    "scripts/",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "keywords": [
+    "git",
+    "tui",
+    "terminal",
+    "dashboard",
+    "cli",
+    "textual"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lebiraja/gitpulse.git"
+  },
+  "homepage": "https://github.com/lebiraja/gitpulse#readme",
+  "bugs": {
+    "url": "https://github.com/lebiraja/gitpulse/issues"
+  },
+  "author": "lebiraja",
+  "license": "AGPL-3.0"
+}

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -1,0 +1,51 @@
+"use strict";
+
+/**
+ * postinstall.js — runs after `npm install -g gitpulse`.
+ *
+ * Bootstraps the Python venv and installs the version-pinned gitpulse-tui
+ * package. Crucially, a failure here NEVER hard-fails `npm install`: it prints
+ * actionable guidance and exits 0, because the launcher (bin/gitpulse.js)
+ * self-heals on first run. This also keeps `npm install --ignore-scripts`
+ * users working — the launcher rebuilds on demand.
+ */
+
+const path = require("path");
+const { ensurePythonPackage } = require("../lib/install");
+
+function main() {
+  // Allow CI / Docker layer caching to skip the Python bootstrap.
+  if (process.env.GITPULSE_SKIP_POSTINSTALL === "1") {
+    console.log("GITPULSE_SKIP_POSTINSTALL=1 — skipping Python setup.");
+    return;
+  }
+
+  const pkg = require(path.join(__dirname, "..", "package.json"));
+
+  try {
+    ensurePythonPackage({ targetVersion: pkg.version });
+    console.log("\n✓ GitPulse is ready. Run `gitpulse` to launch.\n");
+  } catch (err) {
+    // Do not fail the npm install — degrade gracefully.
+    const msg = err && err.message ? err.message : String(err);
+    console.warn(
+      [
+        "",
+        "────────────────────────────────────────────────────────────",
+        " GitPulse: Python setup did not complete during npm install.",
+        "────────────────────────────────────────────────────────────",
+        msg,
+        "",
+        " This is not fatal — GitPulse will try again automatically the",
+        " first time you run `gitpulse`. To retry now:",
+        "",
+        "   GITPULSE_FORCE_REINSTALL=1 gitpulse --version",
+        "────────────────────────────────────────────────────────────",
+        "",
+      ].join("\n"),
+    );
+  }
+}
+
+main();
+process.exit(0);

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -56,6 +56,14 @@ def main() -> None:
         rf'\g<1>"{new_version}"',
     )
 
+    # Update npm/package.json — keeps the npm wrapper version in lockstep
+    # with the PyPI release (npm vX.Y.Z installs gitpulse-tui==X.Y.Z).
+    update_file(
+        "npm/package.json",
+        r'("version"\s*:\s*)"([^"]+)"',
+        rf'\g<1>"{new_version}"',
+    )
+
     # Output the new version so GitHub Actions can capture it
     print(new_version)
 


### PR DESCRIPTION
Make GitPulse installable via `npm install -g gitpulse` without duplicating any application logic. The npm package is a thin launcher (Option 1 architecture): npm handles distribution + bootstrap, while the Python package (gitpulse-tui on PyPI) remains the single source of truth for all CLI/TUI behaviour.

New npm/ package:
- package.json: name "gitpulse", bin entry, postinstall hook, zero runtime dependencies, files allowlist
- lib/paths.js: cross-platform path helpers (~/.gitpulse state dir, platform-aware venv python path)
- lib/python.js: host Python detection, requires 3.10+, probes python3/python (py -3 on Windows)
- lib/install.js: idempotent venv bootstrapper — creates an isolated venv at ~/.gitpulse/venv and installs the exact-pinned gitpulse-tui==<version>; rich error remediation (PEP 668 venv module missing, network errors, version-not-yet-on-PyPI race, EACCES)
- scripts/postinstall.js: runs the bootstrap on npm install; never hard-fails npm install (exit 0 + guidance) so the launcher can self-heal; honours GITPULSE_SKIP_POSTINSTALL
- bin/gitpulse.js: launcher — self-heals if the venv is missing/stale, spawns `<venv>/python -m gitpulse` with stdio:'inherit' for full TUI passthrough, forwards all args transparently and SIGINT/SIGTERM, propagates the child exit code
- README.md + LICENSE (AGPL-3.0, matching the project)

CI / release:
- bump_version.py: also bump npm/package.json so npm and PyPI versions stay in lockstep (npm vX.Y.Z installs gitpulse-tui==X.Y.Z)
- publish.yml: include npm/package.json in the version-bump commit; expose new_version as a job output; add a publish-npm job that waits for the pinned version to be live on PyPI (poll loop) before running `npm publish`, eliminating the publish-timing race

Wrapper behaviour is controlled only via env vars
(GITPULSE_FORCE_REINSTALL, GITPULSE_SKIP_POSTINSTALL) so argument forwarding to the Python CLI stays 100% transparent.

Action required: add an NPM_TOKEN repository secret for CI publishing.