### PR TITLE
fix: rename npm package to gitpulse-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ launcher — it bootstraps an isolated Python environment and runs the same
 Python application (no logic is duplicated):
 
 ```bash
-npm install -g gitpulse
+npm install -g gitpulse-tui
 ```
 
+The CLI command is still `gitpulse` once installed.
 This requires Python 3.10+ on your system; the wrapper handles the rest.
 See [npm/README.md](./npm/README.md) for details and troubleshooting.
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -13,7 +13,7 @@ source of truth.
 ## Install
 
 ```bash
-npm install -g gitpulse
+npm install -g gitpulse-tui
 ```
 
 On install, the wrapper:
@@ -44,7 +44,7 @@ All arguments are forwarded transparently to the Python CLI.
 ## How it works
 
 ```
-npm install -g gitpulse
+npm install -g gitpulse-tui
    └─ postinstall → ~/.gitpulse/venv → pip install gitpulse-tui==<version>
 
 gitpulse <args>
@@ -77,7 +77,7 @@ GITPULSE_FORCE_REINSTALL=1 gitpulse --version
 **`Python 3.10 or newer ... not found`**
 
 Install Python 3.10+ from <https://www.python.org/downloads/>, then re-run
-`npm install -g gitpulse`.
+`npm install -g gitpulse-tui`.
 
 **The environment looks broken**
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitpulse",
+  "name": "gitpulse-tui",
   "version": "1.2.7",
   "description": "Git Repo Dashboard TUI — npm launcher for the Python GitPulse package (gitpulse-tui on PyPI)",
   "bin": {


### PR DESCRIPTION
npm rejected the name `gitpulse` with E403 — it is too similar to the existing package `git-pulse` (npm's typosquatting protection; the earlier 404 only meant the name was unclaimed, not that it was publishable).

Rename the npm package to `gitpulse-tui`, matching the PyPI package name. The installed CLI command is unchanged — `bin` still maps `gitpulse`, so users continue to run `gitpulse` after installing with `npm install -g gitpulse-tui`.