### PR TITLE
polish(ui): denser sidebar, richer Branches tab, fixed empty panes

### DIFF
--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -90,6 +90,9 @@ class BranchInfo:
     """Information about a local branch."""
     name: str
     is_current: bool
+    last_commit_ts: float = 0.0      # Unix ts of the branch tip
+    last_commit_msg: str = ""         # First line of the tip commit message
+    has_upstream: bool = False        # True if the branch tracks a remote
 
 
 @dataclass
@@ -396,10 +399,31 @@ def get_branches(path: Path) -> list[BranchInfo]:
         current = None
 
     for branch in repo.branches:
+        ts = 0.0
+        msg = ""
+        has_upstream = False
+        try:
+            tip = branch.commit
+            ts = float(tip.committed_date)
+            msg = tip.message.splitlines()[0] if tip.message else ""
+        except Exception:
+            pass
+        try:
+            has_upstream = branch.tracking_branch() is not None
+        except Exception:
+            has_upstream = False
         branches.append(
-            BranchInfo(name=branch.name, is_current=(branch.name == current))
+            BranchInfo(
+                name=branch.name,
+                is_current=(branch.name == current),
+                last_commit_ts=ts,
+                last_commit_msg=msg,
+                has_upstream=has_upstream,
+            )
         )
 
+    # Most-recently-active branch first; current branch always pinned to top.
+    branches.sort(key=lambda b: (not b.is_current, -b.last_commit_ts))
     return branches
 
 

--- a/gitpulse/ui/help_modal.py
+++ b/gitpulse/ui/help_modal.py
@@ -11,7 +11,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.screen import ModalScreen
 from textual.widgets import Static
-from textual.containers import Container
+from textual.containers import Container, ScrollableContainer
 
 _SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
     ("Global", [
@@ -55,20 +55,21 @@ class HelpModal(ModalScreen):
         align: center middle;
     }
     #help-frame {
-        width: 70;
+        width: 72;
+        max-width: 90%;
         height: auto;
         max-height: 90%;
         padding: 1 2;
         background: #111827;
-        border: solid #8b5cf6;
-        border-title-align: left;
+        border: round #8b5cf6;
+        border-title-color: #8b5cf6;
+        border-title-style: bold;
+        border-title-align: center;
     }
-    #help-title {
-        text-style: bold;
-        color: #8b5cf6;
+    #help-scroll {
         width: 100%;
-        text-align: center;
-        margin-bottom: 1;
+        height: auto;
+        max-height: 32;
     }
     #help-body, #help-errors {
         width: 100%;
@@ -84,14 +85,18 @@ class HelpModal(ModalScreen):
         text-align: center;
         color: #6b7280;
         margin-top: 1;
+        border-top: solid #1f2937;
+        padding-top: 1;
     }
     """
 
     def compose(self) -> ComposeResult:
-        with Container(id="help-frame"):
-            yield Static("Keyboard Shortcuts", id="help-title", markup=False)
-            yield Static(self._body(), id="help-body", markup=True)
-            yield Static(self._errors_panel(), id="help-errors", markup=True)
+        frame = Container(id="help-frame")
+        frame.border_title = "Keyboard Shortcuts"
+        with frame:
+            with ScrollableContainer(id="help-scroll"):
+                yield Static(self._body(), id="help-body", markup=True)
+                yield Static(self._errors_panel(), id="help-errors", markup=True)
             yield Static("Esc / q to close", id="help-footer", markup=False)
 
     def _body(self) -> str:

--- a/gitpulse/ui/sidebar.py
+++ b/gitpulse/ui/sidebar.py
@@ -26,9 +26,9 @@ except ImportError:
 # Column layout — character widths, must match the header row below
 # ---------------------------------------------------------------------------
 
-_W_REPO = 13
-_W_BRANCH = 11
-_W_CHANGES = 2
+_W_REPO = 16
+_W_BRANCH = 15
+_W_CHANGES = 3
 
 # Palette
 _TEXT = "#d1d5db"
@@ -46,13 +46,18 @@ def _fit(value: str, width: int) -> str:
     return value.ljust(width)
 
 
-def _status_cell(info: RepoInfo) -> tuple[str, str]:
-    """Return (label, color) for a repo's status."""
+def _status_dot(info: RepoInfo) -> tuple[str, str]:
+    """Return (glyph, color) for a repo's status — a single compact dot.
+
+    The dot's colour carries the status (green=clean, yellow=modified,
+    red=untracked); the separate change-count column carries magnitude.
+    This frees the horizontal room the old "● Modified" label wasted.
+    """
     if info.status == RepoStatus.CLEAN:
-        return "✓ Clean", _GREEN
+        return "✓", _GREEN
     if info.status == RepoStatus.MODIFIED:
-        return "● Modified", _YELLOW
-    return "● Untracked", _RED
+        return "●", _YELLOW
+    return "●", _RED
 
 
 def column_header() -> Text:
@@ -63,9 +68,9 @@ def column_header() -> Text:
     t.append(" ")
     t.append(_fit("Branch", _W_BRANCH))
     t.append(" ")
-    t.append("Ch")
+    t.append("Δ".rjust(_W_CHANGES))
     t.append(" ")
-    t.append("Status")
+    t.append("·")
     return t
 
 
@@ -94,13 +99,14 @@ class RepoListItem(ListItem):
         # Branch
         t.append(_fit(info.branch, _W_BRANCH), style=_ACCENT)
         t.append(" ")
-        # Changes count
+        # Changes count — only show the number when there is something to show
         count = info.modified_count
-        t.append(str(count).rjust(_W_CHANGES), style=_MUTED if count == 0 else _TEXT)
+        count_str = (str(count) if count else "·").rjust(_W_CHANGES)
+        t.append(count_str, style=_MUTED if count == 0 else _TEXT)
         t.append(" ")
-        # Status
-        label, color = _status_cell(info)
-        t.append(label, style=color)
+        # Status — single colour-coded dot (colour == status)
+        glyph, color = _status_dot(info)
+        t.append(glyph, style=f"bold {color}")
 
         yield Static(t)
 

--- a/gitpulse/ui/styles.tcss
+++ b/gitpulse/ui/styles.tcss
@@ -261,6 +261,17 @@ DataTable > .datatable--odd-row {
     border-top: solid #1f2937;
 }
 
+/* Section headers for sparse panes (Branches / Tags) */
+#branch-header,
+#tags-header {
+    height: 1;
+    dock: top;
+    background: #111827;
+    color: #6b7280;
+    padding: 0 1;
+    border-bottom: solid #1f2937;
+}
+
 StatusFileItem {
     height: 1;
     padding: 0 1;

--- a/gitpulse/ui/styles.tcss
+++ b/gitpulse/ui/styles.tcss
@@ -264,8 +264,8 @@ DataTable > .datatable--odd-row {
 /* Section headers for sparse panes (Branches / Tags) */
 #branch-header,
 #tags-header {
+    width: 100%;
     height: 1;
-    dock: top;
     background: #111827;
     color: #6b7280;
     padding: 0 1;
@@ -479,9 +479,10 @@ Tree > .tree--highlight {
 }
 
 BranchListItem {
-    height: 1;
+    height: 2;
     padding: 0 1;
     background: #0b0f14;
+    border-bottom: solid #1f2937;
 }
 
 BranchListItem:hover {

--- a/gitpulse/ui/tabs.py
+++ b/gitpulse/ui/tabs.py
@@ -599,12 +599,13 @@ class FilePreviewModal(ModalScreen):
 # ===================================================================
 
 class BranchListItem(ListItem):
-    """A single branch row in the Branches tab."""
+    """A two-line branch row in the Branches tab: name + tip-commit context."""
 
     DEFAULT_CSS = """
     BranchListItem {
-        height: auto;
+        height: 2;
         padding: 0 1;
+        border-bottom: solid #1f2937;
     }
     """
 
@@ -613,11 +614,28 @@ class BranchListItem(ListItem):
         self.branch_info = branch_info
 
     def compose(self) -> ComposeResult:
-        if self.branch_info.is_current:
-            label = f"[bold #22c55e]● {self.branch_info.name}[/]  [dim italic](current)[/]"
+        b = self.branch_info
+        # Line 1 — marker + name + tags
+        if b.is_current:
+            line1 = f"[bold #22c55e]● {b.name}[/]  [dim italic](current)[/]"
         else:
-            label = f"[#d1d5db]  {self.branch_info.name}[/]"
-        yield Static(label, markup=True)
+            line1 = f"[#8b5cf6]  {b.name}[/]"
+        tags = []
+        if b.has_upstream:
+            tags.append("[#6b7280]⇅ tracked[/]")
+        else:
+            tags.append("[#6b7280]local-only[/]")
+        line1 += "   " + " ".join(tags)
+
+        # Line 2 — tip commit subject + relative time (muted)
+        rel = relative_time(b.last_commit_ts) if b.last_commit_ts else ""
+        msg = b.last_commit_msg[:48] + ("…" if len(b.last_commit_msg) > 48 else "")
+        if msg:
+            line2 = f"     [#6b7280]{msg}[/]  [dim]· {rel}[/]"
+        else:
+            line2 = "     [dim #6b7280]no commits[/]"
+
+        yield Static(f"{line1}\n{line2}", markup=True)
 
 
 # ===================================================================
@@ -848,6 +866,11 @@ class MainPanel(Widget):
 
             # ── Branches ──
             with Vertical(id="pane-branches", classes="content-pane"):
+                yield Static(
+                    "[#6b7280]Local branches[/]",
+                    id="branch-header",
+                    markup=True,
+                )
                 yield ListView(id="branch-list")
                 yield Static(
                     "[#6b7280]  Enter switch branch   n new branch   d delete branch[/]",
@@ -871,6 +894,11 @@ class MainPanel(Widget):
 
             # ── Tags ──
             with Vertical(id="pane-tags", classes="content-pane"):
+                yield Static(
+                    "[#6b7280]Tags[/]",
+                    id="tags-header",
+                    markup=True,
+                )
                 yield DataTable(id="tags-table")
 
             # ── Tree ──
@@ -1213,11 +1241,20 @@ class MainPanel(Widget):
         branch_list: ListView = self.query_one("#branch-list", ListView)
         branch_list.clear()
         branches = data["branches"]
+        header = self.query_one("#branch-header", Static)
         if not branches:
-            branch_list.append(ListItem(
-                Static("[dim italic]No branches found[/]", markup=True)
-            ))
+            header.update("[#6b7280]Local branches[/]")
+            branch_list.append(ListItem(Static(
+                "\n   [dim #6b7280]No local branches found.[/]\n"
+                "   [dim #6b7280]Press [#8b5cf6]n[/] to create one.[/]",
+                markup=True,
+            )))
             return
+        tracked = sum(1 for b in branches if b.has_upstream)
+        header.update(
+            f"[bold #d1d5db]Local branches[/]  "
+            f"[#6b7280]{len(branches)} total · {tracked} tracked[/]"
+        )
         for b in branches:
             branch_list.append(BranchListItem(b))
 
@@ -1246,9 +1283,14 @@ class MainPanel(Widget):
         table: DataTable = self.query_one("#tags-table", DataTable)
         table.clear()
         tags = data["tags"]
+        header = self.query_one("#tags-header", Static)
         if not tags:
-            table.add_row("—", "No tags", "", "")
+            header.update("[#6b7280]Tags[/]")
+            table.add_row("—", "This repo has no tags yet", "", "")
             return
+        header.update(
+            f"[bold #d1d5db]Tags[/]  [#6b7280]{len(tags)} shown[/]"
+        )
         for t in tags:
             table.add_row(t.name, t.date, t.tagger, t.message[:60])
 

--- a/gitpulse/ui/tabs.py
+++ b/gitpulse/ui/tabs.py
@@ -601,13 +601,7 @@ class FilePreviewModal(ModalScreen):
 class BranchListItem(ListItem):
     """A two-line branch row in the Branches tab: name + tip-commit context."""
 
-    DEFAULT_CSS = """
-    BranchListItem {
-        height: 2;
-        padding: 0 1;
-        border-bottom: solid #1f2937;
-    }
-    """
+    # Height / borders governed by styles.tcss (#branch-list / BranchListItem).
 
     def __init__(self, branch_info: BranchInfo, **kwargs) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
## Summary

A focused UI polish pass — no behavioural changes, display-only improvements driven by reviewing real captured screenshots of every screen.

### Sidebar density
- Dropped the redundant `● Modified` status label; status is now a single colour-coded dot (green=clean, yellow=modified, red=untracked).
- Reclaimed width goes to **Repository** (13→16) and **Branch** (11→15) columns, so long branch names like `feat/end-to-end-x` are finally readable.
- Change-count column shows `·` for clean repos instead of `0`.

### Branches tab (was 95% empty space)
- `get_branches()` now attaches each branch's tip-commit timestamp, subject, and upstream-tracking flag (cheap ref reads).
- Branches sorted most-recently-active first; current branch pinned to top.
- `BranchListItem` is now a two-line row: name + tracking tag on top, tip-commit subject + relative time below.
- New header shows `N total · M tracked`; empty state guides the user to press `n`.

### Tags tab
- Section header + friendlier `This repo has no tags yet` empty state.

### Help modal
- Rounded border with centered border-title (consistent with confirm modals), scrollable body so it never overflows, footer separated by a rule.

### Bug fix
- **Fixed a blank Branches detail pane**: the two-line row change (`height: 2`) collided with a leftover `BranchListItem { height: 1 }` in `styles.tcss`. App-level CSS wins over widget `DEFAULT_CSS`, collapsing every row to height 0 and blanking the whole pane. Resolved by keeping sizing in one place (`styles.tcss`) and removing `dock: top` from the new section headers.

## Verification
- 107/107 tests pass
- App launches clean in a real terminal
- Re-captured screenshots confirm sidebar, Branches, Tags, and Help all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)