### PR TITLE
ci: push releases with RELEASE_TOKEN to satisfy Protect Main ruleset

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # A personal access token or the default GITHUB_TOKEN is required to push back
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Push back to a branch protected by the "Protect Main" ruleset.
+          # GITHUB_TOKEN authenticates as github-actions[bot], which is NOT on
+          # the ruleset bypass list and cannot be added via the UI, so the
+          # bump-commit / tag pushes were rejected (GH013 "Changes must be made
+          # through a pull request"). RELEASE_TOKEN is a PAT owned by a user on
+          # the bypass list; pushing with it inherits that bypass. Falls back to
+          # GITHUB_TOKEN if the secret is unset (e.g. on forks).
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Commit version bump
         run: |
           git add pyproject.toml gitpulse/utils.py npm/package.json
-          git commit -m "chore: bump version to ${{ env.NEW_VERSION }} [skip ci]"
+          git commit \
+            -m "chore: bump version to ${{ env.NEW_VERSION }} [skip ci]" \
+            -m "Co-Authored-By: lebiraja <130662829+lebiraja@users.noreply.github.com>"
           git push origin main
 
       - name: Create and push tag


### PR DESCRIPTION
## Problem

The **Build and Publish** workflow fails on every merge to `main` at the *Commit version bump* step:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

The job uses `GITHUB_TOKEN`, which authenticates as `github-actions[bot]`. That bot is **not** on the *Protect Main* ruleset's bypass list, and GitHub's UI does **not** offer `github-actions[bot]` (a virtual `[bot]` actor) as an addable bypass actor or collaborator. So the post-merge bump-commit and tag pushes to `main` are rejected — and because that step fails early, **nothing downstream runs**: no tag, no GitHub release, no PyPI publish, no npm publish.

## Fix

Check out with a user-owned PAT (`RELEASE_TOKEN`) instead of `GITHUB_TOKEN`. The PAT belongs to a user on the ruleset bypass list, so the bump-commit and tag pushes are attributed to that user and clear the ruleset. `actions/checkout` persists the credential, so the existing `git push origin main` / tag-push steps need no further changes.

Falls back to `GITHUB_TOKEN` when the secret is unset (e.g. on forks), so forks still build.

## Required before merge

Add a repository secret named **`RELEASE_TOKEN`**:
- **Classic PAT** with the `repo` scope, **or**
- **Fine-grained PAT** scoped to `gitpulse` with **Contents: Read and write** (and **Workflows: Read and write** if a bump ever touches `.github/`).

The token owner must be on the *Protect Main* bypass list (`lebiraja` already is).

## Note on this release

`v1.2.14` was bumped but never pushed/published on PR #21's merge. After this PR merges with the secret in place, the workflow will bump → `v1.2.15` and complete the full publish chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)