### PR TITLE
feat: fleet overhaul — UI fixes, agent-facing output, release safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 matters: config.py branches between the tomli backport and
+        # stdlib tomllib at 3.11, so the backport path needs real coverage.
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build and validate distribution metadata
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          python -m build
+          twine check dist/*

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,0 +1,33 @@
+name: Latest deps
+
+# The pinned upper bounds in pyproject.toml protect users from upstream
+# breaking changes, but they go stale silently. This job installs the newest
+# releases of Textual, Rich, and GitPython and runs the suite, so upstream
+# breakage surfaces as a failing scheduled build instead of a user bug report.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install with unpinned upstream deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install --upgrade textual rich gitpython
+
+      - name: Report resolved versions
+        run: pip list | grep -Ei 'textual|rich|gitpython'
+
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,35 @@ on:
       - main
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 matters: config.py branches between the tomli backport and
+        # stdlib tomllib at 3.11, so the backport path needs real coverage.
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q
+
   build-and-publish:
     runs-on: ubuntu-latest
+    # Never publish a build whose tests did not pass.
+    needs: test
     permissions:
       contents: write
     # Prevent infinite loop if the commit is from the bot itself

--- a/FIXES.md
+++ b/FIXES.md
@@ -1,0 +1,135 @@
+# FIXES
+
+Running bug log. Newest on top.
+
+---
+
+## 2026-08-07 — Stale `Highlighted` event clobbers restored selection
+
+**Symptom:** After filtering, the correct repo stayed selected for one frame and
+then silently reverted to the first row.
+
+**Root cause:** `RepoSidebar.populate()` calls `ListView.clear()` and re-appends
+rows. Those mutations queue `Highlighted` events that are delivered *after*
+`populate()` returns, carrying items from the *previous* list. The late event
+overwrote the selection `populate()` had just restored. Only surfaced under the
+async test pilot; in manual use it looked like intermittent flicker.
+
+**Fix:** `gitpulse/ui/sidebar.py:297` — `on_list_view_highlighted` now ignores
+any event whose `repo_info.path` is not in `_current_repos`.
+
+**Verified:** `tests/test_ui_behaviour.py::TestFilterPreservesSelection` (3
+tests), stable across 3 consecutive runs.
+
+---
+
+## 2026-08-07 — Filter box hijacked repo selection on every keystroke
+
+**Symptom:** Typing in the filter box jumped the main panel to a different repo
+on every character typed.
+
+**Root cause:** `_apply_filter` called `_select_repo(self.repos[0])`
+unconditionally after each keystroke, and `sidebar.populate()` was called
+without `keep_path`, resetting `list_view.index` to 0. Two independent resets on
+the same path. Each one re-triggered the threaded tab loaders, so it also caused
+redundant git work per character. `_apply_fleet_filter` had the same defect.
+
+**Fix:** `gitpulse/main.py:511` — added `_repopulate_preserving_selection()`,
+which passes `keep_path` through and only falls back to the first row when the
+current selection has genuinely been filtered out. Both call sites now use it.
+
+**Verified:** `tests/test_ui_behaviour.py::TestFilterPreservesSelection`.
+
+---
+
+## 2026-08-07 — Repo scan ran ~7 sequential git subprocesses per repo
+
+**Symptom:** Startup and every `r` refresh took time proportional to repo count;
+the sidebar sat on "scanning…" for seconds on a large fleet.
+
+**Root cause:** `_scan_worker` enriched repos with a plain list comprehension
+(`[get_repo_info(p) for p in paths]`). Each `get_repo_info` call shells out to
+git ~7 times (`rev_list`, `shortlog`, `log`, two `iter_commits`, `stash list`,
+`for_each_ref`), all strictly serialized. `parallel.run_parallel` already
+existed and was used by digest/bulk/stale — just not by the main scan.
+
+**Fix:** `gitpulse/main.py:378` — fan out via `run_parallel` using
+`cfg.bulk.max_workers`. Per-repo exceptions are collected into `_scan_errors`
+and drained into the error log on the main thread.
+
+**Verified:** `tests/test_api.py::TestScanFleet`; TUI smoke test against a
+3-repo fleet.
+
+---
+
+## 2026-08-07 — Error ring buffer was unreachable
+
+**Symptom:** Failures showed a 2-second toast with a short hint; the detailed
+error was unrecoverable.
+
+**Root cause:** `_error_log` was allocated and maintained by `_record_error`,
+but nothing ever read it — no screen, no binding. It was also only wired to
+scan failures; bulk-op and branch-switch failures never reached it.
+
+**Fix:** Added `gitpulse/ui/error_log.py` (`ErrorLogScreen`), bound to `e`.
+Bulk-op failures now route through `_record_error`
+(`gitpulse/main.py:230`), and scan failures report a count with a "press e"
+hint. Error text renders with `markup=False` since git stderr can contain
+square brackets.
+
+**Verified:** `tests/test_ui_behaviour.py::TestErrorLog`.
+
+---
+
+## 2026-08-07 — Unreadable repos reported as clean in JSON output
+
+**Symptom:** A directory containing an invalid `.git` was emitted with
+`"status": "clean"`, telling a consumer there was nothing to do.
+
+**Root cause:** `get_repo_info` catches its own exceptions and returns a
+placeholder `RepoInfo` with `branch="unknown"` and no history rather than
+raising. That shape is indistinguishable from a genuinely clean repo, and the
+only signal (`branch == "unknown"`) was undocumented.
+
+**Fix:** `gitpulse/api.py:142` — added `is_unreadable()`; `repo_to_dict` emits
+`"status": "unreadable"` with `"readable": false`. `context.py` lists these
+under "Could not be read" with an explicit "unknown, not clean" note.
+
+**Verified:** `tests/test_api.py::TestSerialization::test_unreadable_repo_is_not_reported_as_clean`,
+`tests/test_context.py::test_unreadable_repo_is_flagged_not_counted_clean`.
+
+---
+
+## 2026-08-07 — Fleet status chips clipped off the sidebar
+
+**Symptom:** At narrow terminal widths only the first chip (`dirty N`) was
+visible; `stale` and `all` were cut off entirely.
+
+**Root cause:** Two compounding issues. `FleetStatus` subclassed `Widget`, and
+its six `width: auto` chips plus a `fleet` label needed 42 columns against a
+sidebar of ~31. Chips were silently clipped rather than wrapping or scrolling.
+
+**Fix:** `gitpulse/ui/fleet_status.py:44` — `FleetStatus` now subclasses
+`Horizontal`; dropped the redundant `fleet` label; abbreviated `behind`/`ahead`
+to `↓`/`↑` and `stash`/`stale` to `stsh`/`stl`, with tooltips carrying the full
+meaning. `styles.tcss` padding reduced to 0 with a 1-column chip margin.
+
+**Verified:** `tests/test_ui_behaviour.py::TestFleetStrip` asserts all six chips
+fit the strip's content area at an 95-column terminal; screenshots at 95 and
+150 columns.
+
+---
+
+## 2026-08-07 — Status tab empty state contradicted the summary card
+
+**Symptom:** With untracked files present, the Status card read "Untracked / 1
+untracked" while the Staged pane below it said "Working tree is clean".
+
+**Root cause:** `_empty_row` hardcoded the subtitle "Working tree is clean" for
+every workspace list. An empty *Staged* list says nothing about the tree.
+
+**Fix:** `gitpulse/ui/tabs.py:1071` — `_empty_row` takes a per-list `hint`;
+each list now passes a subtitle describing only itself ("Press s on a file to
+stage it", etc.).
+
+**Verified:** Screenshot against a repo with untracked files.

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ local Git repository.
 
 **Demo** — GitPulse in action
 
-![GitPulse demo](ss/gitpulse.gif)
+![GitPulse demo](https://raw.githubusercontent.com/lebiraja/gitpulse/main/ss/gitpulse.gif)
 
 **Status tab** — repo summary cards, staged/unstaged/untracked/stash workspace, and the file tree / recent commits / remote summary side panels
 
-![Status tab](ss/status.png)
+![Status tab](https://raw.githubusercontent.com/lebiraja/gitpulse/main/ss/status.png)
 
 **Commits tab** — last N commits with color-coded insertions/deletions
 
-![Commits tab](ss/commits.png)
+![Commits tab](https://raw.githubusercontent.com/lebiraja/gitpulse/main/ss/commits.png)
 
 ## Installation
 
@@ -86,9 +86,35 @@ gitpulse --config path/to.toml     # use a custom config file
 gitpulse --version                 # print version
 
 # Activity digest (prints markdown, no TUI):
-gitpulse --digest --since 7d                 # last 7 days
-gitpulse --digest --since 2024-01-01         # since a date
-gitpulse --digest --author you@example.com   # filter by author
+gitpulse digest --since 7d                 # last 7 days
+gitpulse digest --since 2024-01-01         # since a date
+gitpulse digest --author you@example.com   # filter by author
+```
+
+### For scripts and coding agents
+
+Non-interactive subcommands emit machine-readable fleet state on stdout, so an
+agent can answer "which of my repos have unpushed work?" in a single call:
+
+```bash
+gitpulse scan --json                     # full fleet state as one JSON document
+gitpulse scan --json --dirty             # only repos with uncommitted changes
+gitpulse scan --json --ahead             # only repos with unpushed commits
+gitpulse scan --ndjson                   # one JSON object per line
+gitpulse context                         # Markdown context pack for an LLM prompt
+```
+
+The JSON envelope carries a `schema_version`, ISO-8601 UTC timestamps
+alongside raw epochs, and an `errors` array. Repos that could not be read are
+marked `"status": "unreadable"` with `"readable": false` — never silently
+reported as clean.
+
+GitPulse is also importable as a library. `gitpulse.api` never imports Textual:
+
+```python
+from gitpulse.api import scan_fleet
+
+unpushed = [r for r in scan_fleet("~/Projects") if r.ahead > 0]
 ```
 
 ## Features
@@ -116,7 +142,7 @@ Press `?` inside the app for the full cheat sheet.
 
 | Key | Action |
 |-----|--------|
-| `↑` / `↓` | Navigate the repo list |
+| `↑` / `↓` or `j` / `k` | Navigate the repo list |
 | `[` / `]` | Previous / next tab |
 | `/` | Search / filter repos |
 | `Space` / `*` | Toggle multi-select / select all |
@@ -125,6 +151,7 @@ Press `?` inside the app for the full cheat sheet.
 | `d` | Activity digest |
 | `:` | Bulk action palette |
 | `b` | Stale-branch cleanup |
+| `e` | Error log |
 | `?` | Help |
 | `q` | Quit |
 | `s` / `u` / `a` | Stage / unstage / stage-all (Status tab) |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,61 @@
+# STATUS
+
+Project activity log. Newest on top.
+
+---
+
+## [2026-08-07 15:40] — Fleet overhaul: UI fixes, agent surface, release safety
+
+**What:** Single branch `feat/fleet-overhaul` closing GitHub issues #26–#37
+(epics #23, #24, #25). Three strands: (1) UI/UX correctness — filter selection,
+parallel scan, error log, vim keys, responsive sidebar, fleet strip clipping,
+misleading empty states; (2) agent mode — `gitpulse.api` (Textual-free library
+surface), `gitpulse scan --json/--ndjson`, `gitpulse context` Markdown pack,
+subcommand CLI in `gitpulse/cli.py`; (3) packaging — PyPI metadata, dependency
+ceilings, a CI test gate, and 78 new tests.
+
+**Why:** Competitive research showed every local-git MCP server is pinned to a
+single repository and returns text rather than JSON — "which of my 40 repos have
+unpushed work?" was unanswerable in one call, despite GitPulse already computing
+it. The UI defects were real bugs found by reading `main.py` and `sidebar.py`.
+
+**State:** DONE — 185 tests passing (was 107), TUI verified by screenshot at 95
+and 150 columns.
+
+**Next:** Merge the PR. An MCP server built on `gitpulse.api` is the natural
+follow-on, deliberately left out of scope until the library surface settles.
+
+---
+
+## [2026-08-07 15:40] — Removed dual-import blocks from every module
+
+**What:** Replaced the `try: from gitpulse.x / except ImportError: from x`
+pattern in 12 modules with relative imports. Split `main.py` into `main.py`
+(the Textual app) and `cli.py` (argument parsing + subcommands). Console script
+now points at `gitpulse.cli:main`.
+
+**Why:** The fallback branch mutated `sys.path` at import time, which makes
+`import gitpulse` unsafe inside another process — a blocker for the library API.
+It also meant every new module had to be added in two places.
+
+**State:** DONE
+
+**Next:** — (breaking change noted in the PR: `python gitpulse/main.py` no
+longer works; use `python -m gitpulse`)
+
+---
+
+## [2026-08-07 15:40] — CI now gates publishing on tests
+
+**What:** Added a `test` job (Python 3.10–3.13 matrix) that `build-and-publish`
+depends on. Added `ci.yml` for pull requests and `latest-deps.yml` as a weekly
+canary against unpinned upstream releases.
+
+**Why:** `publish.yml` was the only workflow in the repo and had no test step —
+every push to main published to PyPI *and* npm with 107 tests that had never
+gated a release. The 3.10 matrix entry matters because `config.py` branches
+between the `tomli` backport and stdlib `tomllib`, a path CI never exercised.
+
+**State:** DONE
+
+**Next:** —

--- a/gitpulse/__main__.py
+++ b/gitpulse/__main__.py
@@ -1,3 +1,3 @@
 """Allows running `python -m gitpulse` from anywhere."""
-from gitpulse.main import main
+from gitpulse.cli import main
 main()

--- a/gitpulse/api.py
+++ b/gitpulse/api.py
@@ -1,0 +1,221 @@
+"""
+api.py — Public, UI-free library surface for GitPulse.
+
+This module is the supported entry point for programmatic consumers (agent
+frameworks, scripts, an MCP server). It deliberately imports nothing from
+``gitpulse.ui`` and never pulls in Textual, so it can be imported into a
+non-TUI process cheaply.
+
+    from gitpulse.api import scan_fleet, fleet_to_dict
+
+    fleet = scan_fleet("~/Projects")
+    unpushed = [r for r in fleet if r.ahead > 0]
+
+Everything here is read-only. Mutating operations stay in ``git_ops`` and are
+not re-exported: fanning a write across an entire fleet from a script is a
+different risk profile than doing it behind a confirmation modal.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from . import config as _config
+from .digest import Digest, build_digest
+from .git_ops import RepoInfo, RepoStatus, classify_error, get_repo_info
+from .parallel import run_parallel
+from .scanner import scan_repos
+from .utils import parse_since
+
+# Bump when the emitted dict shape changes incompatibly. Consumers parse this.
+SCHEMA_VERSION = 1
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ScanResult",
+    "is_unreadable",
+    "scan_fleet",
+    "scan_fleet_detailed",
+    "repo_state",
+    "fleet_to_dict",
+    "repo_to_dict",
+    "fleet_digest",
+]
+
+
+class ScanResult:
+    """Outcome of a fleet scan: the repos that resolved, plus per-path errors.
+
+    Errors are carried alongside the results rather than raised, so a single
+    unreadable directory cannot mask an otherwise complete scan.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        repos: list[RepoInfo],
+        errors: list[tuple[Path, str]],
+    ) -> None:
+        self.root = root
+        self.repos = repos
+        self.errors = errors
+        self.scanned_at = datetime.now(timezone.utc)
+
+    def __iter__(self):
+        return iter(self.repos)
+
+    def __len__(self) -> int:
+        return len(self.repos)
+
+
+def _resolve_root(root: str | Path | None) -> Path:
+    """Expand *root*, falling back to configured scan roots then the cwd."""
+    if root is not None:
+        return Path(root).expanduser().resolve()
+    cfg = _config.get()
+    if cfg.scan.roots:
+        return Path(cfg.scan.roots[0]).expanduser().resolve()
+    return Path(".").resolve()
+
+
+def scan_fleet_detailed(
+    root: str | Path | None = None,
+    max_workers: int | None = None,
+) -> ScanResult:
+    """Discover and enrich every git repo under *root*.
+
+    Args:
+        root: Directory to scan. Defaults to the first configured scan root,
+            then the current directory.
+        max_workers: Thread-pool ceiling. Defaults to the configured
+            ``bulk.max_workers``.
+
+    Returns:
+        A :class:`ScanResult` with the resolved repos and any per-path errors.
+    """
+    resolved = _resolve_root(root)
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"{resolved} is not a directory")
+
+    cfg = _config.get()
+    workers = max_workers if max_workers is not None else cfg.bulk.max_workers
+    extra_skip = set(cfg.scan.exclude_dirs) if cfg.scan.exclude_dirs else None
+
+    paths = scan_repos(resolved, extra_skip=extra_skip)
+    results = run_parallel(get_repo_info, paths, max_workers=workers)
+
+    repos: list[RepoInfo] = []
+    errors: list[tuple[Path, str]] = []
+    for path, result in results:
+        if isinstance(result, Exception):
+            _, detail = classify_error(result)
+            errors.append((path, detail))
+        else:
+            repos.append(result)
+
+    repos.sort(key=lambda r: r.last_commit_ts, reverse=True)
+    return ScanResult(root=resolved, repos=repos, errors=errors)
+
+
+def scan_fleet(
+    root: str | Path | None = None,
+    max_workers: int | None = None,
+) -> list[RepoInfo]:
+    """Return every git repo under *root*, most recently active first."""
+    return scan_fleet_detailed(root=root, max_workers=max_workers).repos
+
+
+def repo_state(path: str | Path) -> RepoInfo:
+    """Return the current :class:`RepoInfo` for a single repository."""
+    return get_repo_info(Path(path).expanduser().resolve())
+
+
+def _iso(ts: float) -> str | None:
+    """Format a Unix timestamp as ISO-8601 UTC, or None if unset."""
+    if not ts:
+        return None
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat()
+
+
+def is_unreadable(info: RepoInfo) -> bool:
+    """True if ``get_repo_info`` fell back to placeholder values.
+
+    ``get_repo_info`` catches its own errors and returns a default RepoInfo
+    with ``branch="unknown"`` and no history rather than raising. Left
+    unflagged that shape is indistinguishable from a genuinely clean repo,
+    which would tell a consumer there is nothing to do.
+    """
+    return info.branch == "unknown" and info.last_commit_ts == 0.0
+
+
+def repo_to_dict(info: RepoInfo) -> dict:
+    """Serialize a :class:`RepoInfo` into a JSON-safe dict.
+
+    ``status`` is emitted as a stable lowercase string ("clean", "modified",
+    "untracked") rather than the enum repr — those strings are part of the
+    documented schema. Repos that could not be read are marked
+    ``"status": "unreadable"`` so they are never mistaken for clean.
+    """
+    unreadable = is_unreadable(info)
+    return {
+        "name": info.name,
+        "path": str(info.path),
+        "branch": info.branch,
+        "status": "unreadable" if unreadable else info.status.value.lower(),
+        "readable": not unreadable,
+        "modified_count": info.modified_count,
+        "ahead": info.ahead,
+        "behind": info.behind,
+        "stash_count": info.stash_count,
+        "has_stale_branches": info.has_stale_branches,
+        "last_commit": {
+            "ts": info.last_commit_ts,
+            "iso": _iso(info.last_commit_ts),
+            "message": info.last_commit_msg,
+        },
+        "total_commits": info.total_commits,
+        "contributor_count": info.contributor_count,
+        "commit_activity": list(info.commit_activity),
+    }
+
+
+def fleet_to_dict(result: ScanResult) -> dict:
+    """Serialize a :class:`ScanResult` into the documented JSON envelope."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scanned_at": result.scanned_at.isoformat(),
+        "root": str(result.root),
+        "repo_count": len(result.repos),
+        "repos": [repo_to_dict(r) for r in result.repos],
+        "errors": [{"path": str(p), "error": e} for p, e in result.errors],
+    }
+
+
+def fleet_digest(
+    repos: Iterable[RepoInfo],
+    since: str = "1d",
+    authors: list[str] | None = None,
+    max_workers: int | None = None,
+) -> Digest:
+    """Build an author-activity digest across *repos*.
+
+    Args:
+        repos: Repositories to include, e.g. the output of :func:`scan_fleet`.
+        since: Time window spec ("1d", "7d", "yesterday", "YYYY-MM-DD").
+        authors: Author email patterns. Defaults to the configured authors,
+            then the repo's own ``user.email``.
+        max_workers: Thread-pool ceiling.
+    """
+    cfg = _config.get()
+    workers = max_workers if max_workers is not None else cfg.bulk.max_workers
+    patterns = authors if authors is not None else (cfg.author.emails or [])
+    return build_digest(
+        list(repos), parse_since(since), patterns, max_workers=workers
+    )
+
+
+# Kept importable for consumers that want the status vocabulary without
+# reaching into git_ops directly.
+STATUS_VALUES = tuple(s.value.lower() for s in RepoStatus) + ("unreadable",)

--- a/gitpulse/cli.py
+++ b/gitpulse/cli.py
@@ -1,0 +1,231 @@
+"""
+cli.py — Command-line entry point for GitPulse.
+
+Bare ``gitpulse`` launches the TUI. Subcommands provide non-interactive,
+machine-readable surfaces:
+
+    gitpulse scan --json        fleet state as a JSON document
+    gitpulse scan --ndjson      one repo object per line
+    gitpulse context            fleet state as a Markdown context pack
+    gitpulse digest --since 7d  author activity digest
+
+Textual is imported lazily, only when the TUI is actually launched, so the
+non-interactive subcommands stay fast and importable in headless environments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import config as _config
+from .utils import __version__
+
+_TIME_SPEC_HELP = "1d, 7d, 30d, yesterday, today, or YYYY-MM-DD"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gitpulse",
+        description="GitPulse — Git repo fleet dashboard. Run without arguments for the TUI.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"gitpulse {__version__}"
+    )
+
+    def add_common(target: argparse.ArgumentParser) -> None:
+        """Options every mode accepts, including the bare TUI invocation."""
+        target.add_argument(
+            "--root",
+            type=str,
+            default=None,
+            help="Root directory to scan (default: config scan.roots, else cwd)",
+        )
+        target.add_argument(
+            "--config",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help="Path to config.toml (default: ~/.config/gitpulse/config.toml)",
+        )
+        target.add_argument(
+            "--max-workers",
+            type=int,
+            default=None,
+            metavar="N",
+            help="Thread-pool ceiling for the scan (default: config bulk.max_workers)",
+        )
+
+    # Bare `gitpulse` accepts the common options plus the TUI-only ones.
+    add_common(parser)
+    parser.add_argument(
+        "--commits", type=int, default=10, metavar="N",
+        help="Commits to display per repo in the TUI (default: 10)",
+    )
+    parser.add_argument(
+        "--no-watch", action="store_true", default=False,
+        help="Disable live watch mode",
+    )
+
+    common = argparse.ArgumentParser(add_help=False)
+    add_common(common)
+
+    sub = parser.add_subparsers(dest="command")
+
+    p_scan = sub.add_parser(
+        "scan", parents=[common],
+        help="Print fleet state as JSON and exit",
+        description="Scan the fleet and emit machine-readable state on stdout.",
+    )
+    fmt = p_scan.add_mutually_exclusive_group()
+    fmt.add_argument(
+        "--json", action="store_true", default=False,
+        help="Emit a single JSON document (default)",
+    )
+    fmt.add_argument(
+        "--ndjson", action="store_true", default=False,
+        help="Emit one JSON object per line",
+    )
+    p_scan.add_argument(
+        "--dirty", action="store_true", default=False,
+        help="Only repos with uncommitted changes",
+    )
+    p_scan.add_argument(
+        "--ahead", action="store_true", default=False,
+        help="Only repos with unpushed commits",
+    )
+    p_scan.add_argument(
+        "--indent", type=int, default=2, metavar="N",
+        help="JSON indentation; 0 for compact (default: 2)",
+    )
+
+    p_ctx = sub.add_parser(
+        "context", parents=[common],
+        help="Print fleet state as a Markdown context pack",
+        description="Render fleet state as Markdown sized for an LLM context window.",
+    )
+    p_ctx.add_argument(
+        "--max-repos", type=int, default=40, metavar="N",
+        help="Cap rows listed per section (default: 40)",
+    )
+
+    p_dig = sub.add_parser(
+        "digest", parents=[common],
+        help="Print an author activity digest as Markdown",
+        description="Summarise recent commit activity by author across the fleet.",
+    )
+    p_dig.add_argument(
+        "--since", type=str, default=None, metavar="SPEC",
+        help=f"Time window: {_TIME_SPEC_HELP} (default: config digest.default_window)",
+    )
+    p_dig.add_argument(
+        "--author", action="append", dest="authors", metavar="EMAIL", default=None,
+        help="Author email filter (repeatable; default: git config user.email)",
+    )
+
+    return parser
+
+
+def _cmd_scan(args) -> int:
+    from .api import fleet_to_dict, repo_to_dict, scan_fleet_detailed
+
+    result = scan_fleet_detailed(root=args.root, max_workers=args.max_workers)
+
+    repos = result.repos
+    if args.dirty:
+        repos = [r for r in repos if r.modified_count > 0]
+    if args.ahead:
+        repos = [r for r in repos if r.ahead > 0]
+    result.repos = repos
+
+    if args.ndjson:
+        for repo in repos:
+            sys.stdout.write(json.dumps(repo_to_dict(repo)) + "\n")
+    else:
+        indent = args.indent if args.indent > 0 else None
+        sys.stdout.write(json.dumps(fleet_to_dict(result), indent=indent) + "\n")
+    return 0
+
+
+def _cmd_context(args) -> int:
+    from .api import scan_fleet_detailed
+    from .context import render_context
+
+    result = scan_fleet_detailed(root=args.root, max_workers=args.max_workers)
+    sys.stdout.write(render_context(result, max_repos=args.max_repos))
+    return 0
+
+
+def _cmd_digest(args) -> int:
+    from .api import fleet_digest, scan_fleet
+    from .digest import render_markdown
+
+    cfg = _config.get()
+    since = args.since or cfg.digest.default_window
+    repos = scan_fleet(root=args.root, max_workers=args.max_workers)
+    digest = fleet_digest(
+        repos, since=since, authors=args.authors, max_workers=args.max_workers
+    )
+    sys.stdout.write(render_markdown(digest) + "\n")
+    return 0
+
+
+def _run_tui(args) -> int:
+    # Imported here so the non-interactive subcommands never load Textual.
+    from .main import GitPulseApp
+
+    cfg = _config.get()
+    if args.root is not None:
+        root = Path(args.root).expanduser().resolve()
+    elif cfg.scan.roots:
+        root = Path(cfg.scan.roots[0]).expanduser().resolve()
+    else:
+        root = Path(".").resolve()
+
+    if not root.is_dir():
+        print(f"Error: '{root}' is not a valid directory.", file=sys.stderr)
+        return 1
+
+    watch_enabled = cfg.watch.enabled and not args.no_watch
+    GitPulseApp(root_dir=root, commits=args.commits, watch=watch_enabled).run()
+    return 0
+
+
+def main() -> None:
+    """Console-script entry point."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    # Load config before anything reads scan roots or worker counts.
+    if getattr(args, "config", None):
+        _config.load(Path(args.config))
+
+    handlers = {
+        "scan": _cmd_scan,
+        "context": _cmd_context,
+        "digest": _cmd_digest,
+    }
+    handler = handlers.get(args.command)
+
+    try:
+        if handler is None:
+            sys.exit(_run_tui(args))
+        sys.exit(handler(args))
+    except NotADirectoryError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as exc:
+        # Raised by parse_since on an unrecognised --since spec.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except BrokenPipeError:
+        # Downstream closed the pipe (e.g. `gitpulse scan --json | head`).
+        sys.exit(0)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/gitpulse/context.py
+++ b/gitpulse/context.py
@@ -1,0 +1,129 @@
+"""
+context.py — Fleet state rendered as a Markdown context pack.
+
+Distinct from ``digest.py``: the digest answers "what did I do this week",
+author-filtered and commit-centric. This answers "what is the current state of
+this fleet, and what is unfinished" — state-first, ordered by what needs
+attention, and bounded so a large fleet cannot flood a context window.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .api import ScanResult, is_unreadable
+from .git_ops import RepoInfo, RepoStatus
+from .utils import relative_time
+
+
+def _needs_attention(r: RepoInfo) -> bool:
+    """True if the repo has uncommitted, unpushed, or stashed work."""
+    if is_unreadable(r):
+        return False  # reported separately; not actionable work
+    return (
+        r.status != RepoStatus.CLEAN
+        or r.ahead > 0
+        or r.behind > 0
+        or r.stash_count > 0
+    )
+
+
+def _attention_note(r: RepoInfo) -> str:
+    """Human-readable summary of why a repo needs attention."""
+    bits: list[str] = []
+    if r.modified_count:
+        bits.append(f"{r.modified_count} uncommitted file{'s' if r.modified_count != 1 else ''}")
+    if r.ahead and r.behind:
+        bits.append(f"diverged ({r.ahead} ahead / {r.behind} behind)")
+    elif r.ahead:
+        bits.append(f"{r.ahead} unpushed commit{'s' if r.ahead != 1 else ''}")
+    elif r.behind:
+        bits.append(f"{r.behind} commit{'s' if r.behind != 1 else ''} behind")
+    if r.stash_count:
+        bits.append(f"{r.stash_count} stash{'es' if r.stash_count != 1 else ''}")
+    return ", ".join(bits) if bits else "needs attention"
+
+
+def render_context(result: ScanResult, max_repos: int = 40) -> str:
+    """Render *result* as a Markdown context pack.
+
+    Args:
+        result: A fleet scan from ``api.scan_fleet_detailed``.
+        max_repos: Cap on rows listed in the detail sections. Repos beyond the
+            cap are summarised as a count rather than dropped silently.
+    """
+    repos = result.repos
+    stamp = result.scanned_at.replace(microsecond=0).isoformat()
+
+    lines: list[str] = [
+        f"# Fleet state — {stamp}",
+        "",
+        f"Root: `{result.root}` · {len(repos)} repo{'s' if len(repos) != 1 else ''}",
+        "",
+    ]
+
+    unreadable = [r for r in repos if is_unreadable(r)]
+    readable = [r for r in repos if not is_unreadable(r)]
+    attention = [r for r in readable if _needs_attention(r)]
+    unpushed = [r for r in readable if r.ahead > 0]
+    stale = [r for r in readable if r.has_stale_branches]
+    clean = [r for r in readable if not _needs_attention(r)]
+
+    # --- Needs attention -------------------------------------------------
+    lines.append("## Needs attention")
+    lines.append("")
+    if not attention:
+        lines.append("_Nothing outstanding — every repo is clean and in sync._")
+    else:
+        for r in attention[:max_repos]:
+            lines.append(f"- **{r.name}** (`{r.branch}`) — {_attention_note(r)}")
+        if len(attention) > max_repos:
+            lines.append(f"- _… and {len(attention) - max_repos} more_")
+    lines.append("")
+
+    # --- Unpushed work ---------------------------------------------------
+    if unpushed:
+        lines.append("## Unpushed work")
+        lines.append("")
+        lines.append("| repo | branch | ahead | last commit |")
+        lines.append("|---|---|---|---|")
+        for r in unpushed[:max_repos]:
+            msg = r.last_commit_msg.replace("|", "\\|")
+            when = relative_time(r.last_commit_ts)
+            lines.append(f"| {r.name} | `{r.branch}` | {r.ahead} | {when} — {msg} |")
+        if len(unpushed) > max_repos:
+            lines.append(f"| _… {len(unpushed) - max_repos} more_ | | | |")
+        lines.append("")
+
+    # --- Stale branches --------------------------------------------------
+    if stale:
+        lines.append("## Repos with stale branches")
+        lines.append("")
+        for r in stale[:max_repos]:
+            lines.append(f"- {r.name}")
+        if len(stale) > max_repos:
+            lines.append(f"- _… and {len(stale) - max_repos} more_")
+        lines.append("")
+
+    # --- Clean -----------------------------------------------------------
+    if clean:
+        lines.append(f"## Clean and synced ({len(clean)})")
+        lines.append("")
+        lines.append(", ".join(r.name for r in clean))
+        lines.append("")
+
+    # --- Errors ----------------------------------------------------------
+    if unreadable or result.errors:
+        lines.append("## Could not be read")
+        lines.append("")
+        lines.append(
+            "_State below is unknown, not clean — these were not inspected._"
+        )
+        lines.append("")
+        for r in unreadable[:max_repos]:
+            lines.append(f"- `{r.path}`")
+        for path, err in result.errors[:max_repos]:
+            lines.append(f"- `{path}` — {err}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/gitpulse/digest.py
+++ b/gitpulse/digest.py
@@ -12,14 +12,9 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
-try:
-    from gitpulse.git_ops import RepoInfo, AuthorCommit, get_author_commits, get_author_email
-    from gitpulse.parallel import run_parallel
-    from gitpulse.utils import relative_time
-except ImportError:
-    from git_ops import RepoInfo, AuthorCommit, get_author_commits, get_author_email  # type: ignore
-    from parallel import run_parallel  # type: ignore
-    from utils import relative_time  # type: ignore
+from .git_ops import RepoInfo, AuthorCommit, get_author_commits, get_author_email
+from .parallel import run_parallel
+from .utils import relative_time
 
 
 @dataclass

--- a/gitpulse/docs/architecture.md
+++ b/gitpulse/docs/architecture.md
@@ -43,18 +43,47 @@ This document explains how GitPulse is structured, how data flows through the ap
 
 ## Module Responsibilities
 
+### `cli.py` — Command-Line Entry Point
+
+Owns argument parsing and the non-interactive subcommands. Bare `gitpulse`
+launches the TUI; `scan`, `context`, and `digest` print to stdout and exit.
+Textual is imported lazily inside `_run_tui()`, so the machine-readable
+subcommands never load the UI framework.
+
+### `api.py` — Public Library Surface
+
+The supported entry point for programmatic consumers (scripts, agent
+frameworks, a future MCP server). Read-only, and guaranteed never to import
+Textual — enforced by a test. Provides `scan_fleet()`, `scan_fleet_detailed()`,
+`repo_state()`, and the `fleet_to_dict()` / `repo_to_dict()` serializers that
+define the JSON schema (`SCHEMA_VERSION`).
+
+`is_unreadable()` flags repos where `get_repo_info` fell back to placeholder
+values, so an unreadable directory is emitted as `"status": "unreadable"`
+rather than being mistaken for a clean repo.
+
+### `context.py` — Markdown Context Pack
+
+Renders a fleet scan as state-first Markdown sized for an LLM context window:
+actionable repos first, clean repos collapsed to a name list, bounded by
+`max_repos`. Distinct from `digest.py`, which is author- and commit-centric.
+
 ### `main.py` — Application Orchestrator
 
 The root `GitPulseApp(App)` class owns:
 - The **only mutable repo state** (`_all_repos`, `repos`, `_selected_repo`)
-- The **scan lifecycle** (`_start_scan`, `_scan_worker`, worker state handling)
-- The **search/filter logic** (`_apply_filter`)
+- The **scan lifecycle** (`_start_scan`, `_scan_worker`, worker state handling).
+  `_scan_worker` fans `get_repo_info` out over a thread pool via
+  `parallel.run_parallel` — each call spawns ~7 git subprocesses, so enriching
+  a fleet serially dominated scan time.
+- The **search/filter logic** (`_apply_filter`, `_repopulate_preserving_selection`)
 - **Message routing** — listens for:
   - `RepoSidebar.RepoSelected`
   - `RepoSidebar.SearchChanged`
   - `MainPanel.BranchSwitchRequested`
   - `MainPanel.ReloadRequested` _(new)_ — triggers sidebar rescan after commit/branch ops
-- **Keybindings** (`q`, `r`, `/`, `Escape`)
+- **Keybindings** — every `Binding` carries a stable `id` (e.g. `app.refresh`)
+  so users can remap it; IDs are treated as API once released.
 
 Neither the sidebar nor the tabs know about each other. All cross-widget communication goes through the app.
 
@@ -144,7 +173,8 @@ on_mount()
   └── _start_scan()
         └── run_worker(_scan_worker, thread=True)
               ├── scanner.scan_repos(root)          → list[Path]
-              └── git_ops.get_repo_info(path) × N   → list[RepoInfo]
+              └── run_parallel(get_repo_info, paths) → list[RepoInfo]
+                    (per-repo failures captured, not raised)
 
 on_worker_state_changed(SUCCESS)
   ├── sidebar.populate(repos)
@@ -180,7 +210,14 @@ User types in search box
               └── post RepoSidebar.SearchChanged(query)
                     └── GitPulseApp.on_repo_sidebar_search_changed()
                           └── _apply_filter(query)
-                                └── sidebar.populate(filtered_repos)
+                                └── _repopulate_preserving_selection()
+                                      └── sidebar.populate(repos, keep_path=…)
+
+The active repo is only re-selected when it has been filtered out of view.
+`populate()` clears and refills the ListView, and those mutations queue
+`Highlighted` events that arrive afterwards; `on_list_view_highlighted` drops
+any event whose item is no longer in the current list, so a stale event cannot
+clobber the restored selection.
 ```
 
 ### Branch Switch

--- a/gitpulse/docs/contributing.md
+++ b/gitpulse/docs/contributing.md
@@ -27,10 +27,10 @@ source .venv/bin/activate   # Linux/macOS
 pip install -r requirements.txt
 
 # 4. Run the app (scan your ~/projects)
-python main.py
+python -m gitpulse
 
 # 5. Run against a specific folder (great for testing with a small set of repos)
-python main.py --root /tmp/test-repos
+python -m gitpulse --root /tmp/test-repos
 ```
 
 ### Creating test repos
@@ -45,7 +45,7 @@ for name in alpha beta gamma; do
   git commit --allow-empty -m "Initial commit"
   cd -
 done
-python main.py --root /tmp/test-repos
+python -m gitpulse --root /tmp/test-repos
 ```
 
 ---
@@ -249,7 +249,7 @@ if child.is_dir() and child.name not in SKIP_DIRS:
 
 Run with the `--dev` flag to open the Textual inspector:
 ```bash
-python main.py --dev
+python -m gitpulse --dev
 ```
 This opens a separate browser-based panel showing the widget tree, CSS, and events in real time.
 
@@ -257,7 +257,7 @@ This opens a separate browser-based panel showing the widget tree, CSS, and even
 
 Textual logs to stderr by default. Capture them:
 ```bash
-python main.py 2>debug.log
+python -m gitpulse 2>debug.log
 tail -f debug.log
 ```
 

--- a/gitpulse/docs/index.md
+++ b/gitpulse/docs/index.md
@@ -33,10 +33,10 @@ source .venv/bin/activate      # Linux/macOS
 pip install -r requirements.txt
 
 # Run against your ~/projects directory
-python main.py
+python -m gitpulse
 
 # Run against a custom directory
-python main.py --root /path/to/your/repos
+python -m gitpulse --root /path/to/your/repos
 ```
 
 ---

--- a/gitpulse/docs/installation.md
+++ b/gitpulse/docs/installation.md
@@ -47,7 +47,7 @@ gitpulse          # ✅ works
 
 ```toml
 [project.scripts]
-gitpulse = "gitpulse.main:main"
+gitpulse = "gitpulse.cli:main"
 ```
 
 This registers the `gitpulse` command in the venv's `bin/` directory when installed. It points directly to the `main()` function in `gitpulse/main.py`.
@@ -62,26 +62,23 @@ This tells setuptools to include the `gitpulse` package and its `gitpulse.ui` su
 
 ---
 
-## How Imports Work in Both Modes
+## How Imports Work
 
-`main.py` supports two run modes with a **try/except import block**:
+Modules use **relative imports** throughout:
 
 ```python
-try:
-    # Installed package mode: gitpulse command / python -m gitpulse
-    from gitpulse.scanner import scan_repos
-    from gitpulse.git_ops import get_repo_info, ...
-    from gitpulse.ui.sidebar import RepoSidebar
-    from gitpulse.ui.tabs import MainPanel
-except ImportError:
-    # Direct execution mode: python main.py
-    from scanner import scan_repos
-    from git_ops import get_repo_info, ...
-    from ui.sidebar import RepoSidebar
-    from ui.tabs import MainPanel
+from .scanner import scan_repos
+from .git_ops import get_repo_info
+from .ui.sidebar import RepoSidebar
 ```
 
-The CSS path is also made absolute so it works from any working directory:
+Earlier versions carried a `try`/`except ImportError` block in every module so
+that `python main.py` would work from inside the package directory. That
+fallback mutated `sys.path` at import time, which made `import gitpulse` unsafe
+inside another process, so it was removed. Run the package with `python -m
+gitpulse` (or the `gitpulse` console script) instead.
+
+The CSS path is made absolute so it works from any working directory:
 ```python
 CSS_PATH = str(Path(__file__).parent / "ui" / "styles.tcss")
 ```
@@ -92,15 +89,15 @@ CSS_PATH = str(Path(__file__).parent / "ui" / "styles.tcss")
 
 You can always run directly without installing:
 ```bash
-cd /path/to/git-tui/gitpulse
+cd /path/to/git-tui
 source .venv/bin/activate
-python main.py --root ~/projects
+python -m gitpulse --root ~/projects
 ```
 
 Or:
 ```bash
-cd /path/to/git-tui/gitpulse
-.venv/bin/python main.py --root ~/projects
+cd /path/to/git-tui
+.venv/bin/python -m gitpulse --root ~/projects
 ```
 
 ---

--- a/gitpulse/git_ops.py
+++ b/gitpulse/git_ops.py
@@ -17,10 +17,7 @@ from pathlib import Path
 
 from git import Repo, InvalidGitRepositoryError, GitCommandError
 
-try:
-    from gitpulse.utils import relative_time
-except ImportError:
-    from utils import relative_time  # type: ignore[no-redef]
+from .utils import relative_time
 
 
 # ---------------------------------------------------------------------------

--- a/gitpulse/main.py
+++ b/gitpulse/main.py
@@ -1,69 +1,42 @@
 """
-main.py — GitPulse entry point.
+main.py — The GitPulse Textual application.
 
-Launches the Textual TUI application. Accepts CLI arguments to configure
-the scan root, number of commits to show, and version output.
-Repos are sorted by most recent commit date.
+Defines GitPulseApp, the root TUI. Argument parsing and the non-interactive
+subcommands live in gitpulse.cli; this module is imported only when the TUI is
+actually launched.
 
 Scanning runs in a background worker thread so the UI stays responsive.
 """
 
 from __future__ import annotations
 
-import argparse
-import sys
 from pathlib import Path
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.widgets import Footer, Input
+from textual.widgets import Footer, Input, ListView
 from textual.containers import Horizontal, Vertical
 from textual.worker import Worker, WorkerState
 
-# Support both installed-package imports (gitpulse.scanner) and
-# direct execution (python main.py) by trying package import first.
-try:
-    from gitpulse.scanner import scan_repos
-    from gitpulse.git_ops import (
-        get_repo_info, switch_branch, is_dirty, classify_error,
-        stash_create, RepoInfo,
-    )
-    from gitpulse.ui.sidebar import RepoSidebar
-    from gitpulse.ui.tabs import MainPanel
-    from gitpulse.ui.header import AppHeader, TAB_IDS
-    from gitpulse.ui.help_modal import HelpModal
-    from gitpulse.ui.fleet_status import FleetStatus
-    from gitpulse.ui.digest_screen import DigestScreen
-    from gitpulse.ui.command_palette import CommandPaletteModal
-    from gitpulse.ui.bulk_results import BulkResultsScreen
-    from gitpulse.ui.stale_screen import StaleScreen
-    from gitpulse.ui.confirm_modal import ConfirmModal, DirtyTreeModal
-    from gitpulse.utils import __version__, parse_since
-    from gitpulse import config as _config
-    from gitpulse import watcher as _watcher
-except ImportError:
-    # Running directly: python main.py
-    _THIS_DIR = Path(__file__).resolve().parent
-    if str(_THIS_DIR) not in sys.path:
-        sys.path.insert(0, str(_THIS_DIR))
-    from scanner import scan_repos  # type: ignore[no-redef]
-    from git_ops import (  # type: ignore[no-redef]
-        get_repo_info, switch_branch, is_dirty, classify_error,
-        stash_create, RepoInfo,
-    )
-    from ui.sidebar import RepoSidebar  # type: ignore[no-redef]
-    from ui.tabs import MainPanel  # type: ignore[no-redef]
-    from ui.header import AppHeader, TAB_IDS  # type: ignore[no-redef]
-    from ui.help_modal import HelpModal  # type: ignore[no-redef]
-    from ui.fleet_status import FleetStatus  # type: ignore[no-redef]
-    from ui.digest_screen import DigestScreen  # type: ignore[no-redef]
-    from ui.command_palette import CommandPaletteModal  # type: ignore[no-redef]
-    from ui.bulk_results import BulkResultsScreen  # type: ignore[no-redef]
-    from ui.stale_screen import StaleScreen  # type: ignore[no-redef]
-    from ui.confirm_modal import ConfirmModal, DirtyTreeModal  # type: ignore[no-redef]
-    from utils import __version__, parse_since  # type: ignore[no-redef]
-    import config as _config  # type: ignore[no-redef]
-    import watcher as _watcher  # type: ignore[no-redef]
+from . import config as _config
+from . import watcher as _watcher
+from .git_ops import (
+    RepoInfo, classify_error, get_repo_info, is_dirty, stash_create,
+    switch_branch,
+)
+from .parallel import run_parallel
+from .scanner import scan_repos
+from .ui.bulk_results import BulkResultsScreen
+from .ui.command_palette import CommandPaletteModal
+from .ui.confirm_modal import ConfirmModal, DirtyTreeModal
+from .ui.digest_screen import DigestScreen
+from .ui.error_log import ErrorLogScreen
+from .ui.fleet_status import FleetStatus
+from .ui.header import AppHeader, TAB_IDS
+from .ui.help_modal import HelpModal
+from .ui.sidebar import RepoSidebar
+from .ui.stale_screen import StaleScreen
+from .ui.tabs import MainPanel
 
 
 class GitPulseApp(App):
@@ -80,21 +53,27 @@ class GitPulseApp(App):
     TITLE = "GitPulse"
     SUB_TITLE = "Git Repo Dashboard"
 
+    # Every binding carries a stable `id` so users can remap it from
+    # config.toml ([keymap] section). IDs are API — renaming one breaks
+    # a user's keymap, so treat them as fixed once released.
     BINDINGS = [
-        Binding("q", "quit", "Quit", show=True),
-        Binding("r", "refresh", "Refresh", show=True),
-        Binding("w", "toggle_watch", "Watch", show=True),
-        Binding("d", "open_digest", "Digest", show=True),
-        Binding("colon", "open_palette", "Actions", show=True),
-        Binding("b", "open_stale", "Stale", show=True),
-        Binding("P", "push_all", "Push all", show=True),
-        Binding("slash", "search", "Search", show=True),
-        Binding("escape", "clear_search", "Clear", show=False),
-        Binding("tab", "focus_next", "Next", show=False),
-        Binding("shift+tab", "focus_previous", "Prev", show=False),
-        Binding("right_square_bracket", "next_tab", "Next Tab", show=False),
-        Binding("left_square_bracket", "prev_tab", "Prev Tab", show=False),
-        Binding("question_mark", "open_help", "Help", show=True),
+        Binding("q", "quit", "Quit", id="app.quit", show=True),
+        Binding("r", "refresh", "Refresh", id="app.refresh", show=True),
+        Binding("w", "toggle_watch", "Watch", id="app.toggle_watch", show=True),
+        Binding("d", "open_digest", "Digest", id="app.digest", show=True),
+        Binding("colon", "open_palette", "Actions", id="app.palette", show=True),
+        Binding("b", "open_stale", "Stale", id="app.stale", show=True),
+        Binding("P", "push_all", "Push all", id="app.push_all", show=True),
+        Binding("e", "open_error_log", "Errors", id="app.error_log", show=True),
+        Binding("slash", "search", "Search", id="app.search", show=True),
+        Binding("escape", "clear_search", "Clear", id="app.clear_search", show=False),
+        Binding("tab", "focus_next", "Next", id="app.focus_next", show=False),
+        Binding("shift+tab", "focus_previous", "Prev", id="app.focus_prev", show=False),
+        Binding("right_square_bracket", "next_tab", "Next Tab", id="app.next_tab", show=False),
+        Binding("left_square_bracket", "prev_tab", "Prev Tab", id="app.prev_tab", show=False),
+        Binding("j", "cursor_down", "Down", id="app.cursor_down", show=False),
+        Binding("k", "cursor_up", "Up", id="app.cursor_up", show=False),
+        Binding("question_mark", "open_help", "Help", id="app.help", show=True),
     ]
 
     def __init__(
@@ -117,6 +96,7 @@ class GitPulseApp(App):
         self._fleet_category: str = ""  # Active fleet-filter category ("" = none)
         self._error_log: list[str] = []  # Ring buffer of raw error details (cap 50)
         self._bulk_in_flight: int = 0    # Count of active bulk/git workers (for indicator)
+        self._scan_errors: list[str] = []  # Per-repo scan failures, drained on the main thread
 
     # -----------------------------------------------------------------
     # Layout
@@ -224,12 +204,10 @@ class GitPulseApp(App):
 
     def _dispatch_bulk(self, action_key: str, repos: list) -> None:
         """Fan out a bulk git operation over repos using a thread pool worker."""
-        try:
-            from gitpulse.git_ops import git_fetch, git_pull, git_push, git_gc, git_remote_prune, git_clean_dry, get_repo_info
-            from gitpulse.parallel import run_parallel
-        except ImportError:
-            from git_ops import git_fetch, git_pull, git_push, git_gc, git_remote_prune, git_clean_dry, get_repo_info  # type: ignore[no-redef]
-            from parallel import run_parallel  # type: ignore[no-redef]
+        from .git_ops import (
+            git_clean_dry, git_fetch, git_gc, git_pull, git_push,
+            git_remote_prune,
+        )
 
         _ops = {
             "fetch":   lambda r: git_fetch(r.path),
@@ -252,6 +230,11 @@ class GitPulseApp(App):
         def _worker() -> None:
             def _progress(completed, total, repo, result):
                 self.call_from_thread(results_screen.append_row, repo, result)
+                if isinstance(result, Exception):
+                    _, detail = classify_error(result)
+                    self.call_from_thread(
+                        self._record_error, f"{action_key} · {repo.name}: {detail}"
+                    )
 
             run_parallel(op, repos, max_workers=cfg.bulk.max_workers, on_progress=_progress)
             # After bulk refresh, trigger a rescan to update sidebar
@@ -348,6 +331,26 @@ class GitPulseApp(App):
         inp.value = ""
         self.query_one("#repo-list").focus()
 
+    def action_open_error_log(self) -> None:
+        """Show recorded error details (bound to 'e')."""
+        self.push_screen(ErrorLogScreen(self._error_log))
+
+    def _move_cursor(self, delta: int) -> None:
+        """Move the repo-list highlight by *delta* rows (vim j/k)."""
+        lv = self.query_one("#repo-list", ListView)
+        if not lv.children:
+            return
+        current = lv.index if lv.index is not None else 0
+        lv.index = max(0, min(current + delta, len(lv.children) - 1))
+
+    def action_cursor_down(self) -> None:
+        """Move down one repo (vim 'j')."""
+        self._move_cursor(1)
+
+    def action_cursor_up(self) -> None:
+        """Move up one repo (vim 'k')."""
+        self._move_cursor(-1)
+
     # -----------------------------------------------------------------
     # Background scan worker
     # -----------------------------------------------------------------
@@ -371,7 +374,21 @@ class GitPulseApp(App):
         cfg = _config.get()
         extra_skip = set(cfg.scan.exclude_dirs) if cfg.scan.exclude_dirs else None
         paths = scan_repos(self.root_dir, extra_skip=extra_skip)
-        infos = [get_repo_info(p) for p in paths]
+
+        # get_repo_info() spawns ~7 git subprocesses per repo, so enriching a
+        # fleet serially dominates scan time. Fan out over a bounded pool;
+        # run_parallel captures per-item exceptions so one unreadable repo
+        # can't fail the whole scan.
+        results = run_parallel(get_repo_info, paths, max_workers=cfg.bulk.max_workers)
+
+        infos: list[RepoInfo] = []
+        for path, result in results:
+            if isinstance(result, Exception):
+                _, detail = classify_error(result)
+                self._scan_errors.append(f"{path}: {detail}")
+            else:
+                infos.append(result)
+
         infos.sort(key=lambda r: r.last_commit_ts, reverse=True)
         return infos
 
@@ -406,6 +423,18 @@ class GitPulseApp(App):
             infos: list[RepoInfo] = event.worker.result
             self._all_repos = infos
             self.repos = list(infos)
+
+            # Drain per-repo scan failures collected in the worker thread.
+            if self._scan_errors:
+                failed = len(self._scan_errors)
+                for detail in self._scan_errors:
+                    self._record_error(detail)
+                self._scan_errors.clear()
+                self.notify(
+                    f"{failed} repo{'s' if failed != 1 else ''} could not be read — press e",
+                    severity="warning",
+                    timeout=5,
+                )
 
             # Snapshot signatures for watch mode
             self._signatures = _watcher.snapshot(infos)
@@ -503,20 +532,32 @@ class GitPulseApp(App):
         main: MainPanel = self.query_one("#main-panel", MainPanel)
         main.load_repo(repo_info.path, repo_info)
 
+    def _repopulate_preserving_selection(self) -> None:
+        """Refresh the sidebar from ``self.repos``, keeping the current repo selected.
+
+        The active repo only changes when it has been filtered out of view; a
+        narrowing filter must not yank the user away from what they're reading
+        (each re-select also re-triggers the main panel's tab loaders).
+        """
+        keep = self._selected_repo.path if self._selected_repo else None
+        still_visible = keep is not None and any(r.path == keep for r in self.repos)
+
+        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
+        sidebar.populate(self.repos, keep_path=keep if still_visible else None)
+
+        if not still_visible and self.repos:
+            self._select_repo(self.repos[0])
+
     def _apply_filter(self, query: str) -> None:
         """Filter the repo list by name, preserving any active fleet filter."""
         q = query.strip().lower()
         base = self._fleet_filtered_repos()
         self.repos = [r for r in base if q in r.name.lower()] if q else list(base)
-
-        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
-        sidebar.populate(self.repos)
-        if self.repos:
-            self._select_repo(self.repos[0])
+        self._repopulate_preserving_selection()
 
     def _fleet_filtered_repos(self) -> list[RepoInfo]:
         """Return _all_repos filtered by the current fleet category (if any)."""
-        from gitpulse.git_ops import RepoStatus  # avoid circular at module level
+        from .git_ops import RepoStatus
         _predicates = {
             "dirty":   lambda r: r.status != RepoStatus.CLEAN,
             "behind":  lambda r: r.behind > 0,
@@ -533,15 +574,10 @@ class GitPulseApp(App):
         """Filter sidebar to repos matching a fleet-status category and highlight chip."""
         self._fleet_category = category
         self.repos = self._fleet_filtered_repos()
-
-        sidebar: RepoSidebar = self.query_one("#sidebar-container", RepoSidebar)
-        sidebar.populate(self.repos)
+        self._repopulate_preserving_selection()
 
         fleet: FleetStatus = self.query_one("#fleet-status", FleetStatus)
         fleet.set_active_filter(category)
-
-        if self.repos:
-            self._select_repo(self.repos[0])
 
     # -----------------------------------------------------------------
     # Message handlers
@@ -632,115 +668,14 @@ class GitPulseApp(App):
 
 
 # -----------------------------------------------------------------------
-# CLI entry point
+# Entry point
 # -----------------------------------------------------------------------
 
-def parse_args() -> argparse.Namespace:
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(
-        prog="gitpulse",
-        description="GitPulse — Git Repo Dashboard TUI",
-    )
-    parser.add_argument(
-        "--root",
-        type=str,
-        default=None,
-        help="Root directory to scan for git repos (default: first entry in config scan.roots, or current directory)",
-    )
-    parser.add_argument(
-        "--commits",
-        type=int,
-        default=10,
-        metavar="N",
-        help="Number of commits to display per repo (default: 10)",
-    )
-    parser.add_argument(
-        "--config",
-        type=str,
-        default=None,
-        metavar="PATH",
-        help="Path to config.toml (default: ~/.config/gitpulse/config.toml)",
-    )
-    parser.add_argument(
-        "--no-watch",
-        action="store_true",
-        default=False,
-        help="Disable live watch mode (default: enabled)",
-    )
-    parser.add_argument(
-        "--digest",
-        action="store_true",
-        default=False,
-        help="Print activity digest as markdown and exit (no TUI)",
-    )
-    parser.add_argument(
-        "--since",
-        type=str,
-        default=None,
-        metavar="SPEC",
-        help="Time window for --digest: 1d, 7d, 30d, yesterday, YYYY-MM-DD (default: 1d)",
-    )
-    parser.add_argument(
-        "--author",
-        action="append",
-        dest="authors",
-        metavar="EMAIL",
-        default=None,
-        help="Author email filter for --digest (repeatable; default: git config user.email)",
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"gitpulse {__version__}",
-    )
-    return parser.parse_args()
-
-
 def main() -> None:
-    """Entry point — called by both `python main.py` and the `gitpulse` command."""
-    args = parse_args()
+    """Backwards-compatible shim — the CLI lives in gitpulse.cli."""
+    from .cli import main as _cli_main
 
-    # Load config first so scan.roots can influence the default root.
-    if args.config:
-        _config.load(Path(args.config))
-    cfg = _config.get()
-
-    if args.root is not None:
-        root = Path(args.root).expanduser().resolve()
-    elif cfg.scan.roots:
-        root = Path(cfg.scan.roots[0]).expanduser().resolve()
-    else:
-        root = Path(".").resolve()
-
-    if not root.is_dir():
-        print(f"Error: '{root}' is not a valid directory.", file=sys.stderr)
-        sys.exit(1)
-
-    if args.digest:
-        # CLI digest mode — no TUI
-        from gitpulse.scanner import scan_repos as _scan
-        from gitpulse.git_ops import get_repo_info as _gri
-        from gitpulse.digest import build_digest as _bd, render_markdown as _rm
-        from gitpulse.utils import parse_since as _ps
-
-        since_spec = args.since or cfg.digest.default_window
-        try:
-            since_ts = _ps(since_spec)
-        except ValueError as e:
-            print(f"Error: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        author_patterns = args.authors or cfg.author.emails or []
-        extra_skip = set(cfg.scan.exclude_dirs) if cfg.scan.exclude_dirs else None
-        paths = _scan(root, extra_skip=extra_skip)
-        repos = [_gri(p) for p in paths]
-        digest = _bd(repos, since_ts, author_patterns, max_workers=cfg.bulk.max_workers)
-        print(_rm(digest))
-        return
-
-    watch_enabled = cfg.watch.enabled and not args.no_watch
-    app = GitPulseApp(root_dir=root, commits=args.commits, watch=watch_enabled)
-    app.run()
+    _cli_main()
 
 
 if __name__ == "__main__":

--- a/gitpulse/stale.py
+++ b/gitpulse/stale.py
@@ -10,12 +10,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-try:
-    from gitpulse.git_ops import BranchDetail, get_branch_details
-    from gitpulse.parallel import run_parallel
-except ImportError:
-    from git_ops import BranchDetail, get_branch_details  # type: ignore
-    from parallel import run_parallel  # type: ignore
+from .git_ops import BranchDetail, get_branch_details
+from .parallel import run_parallel
 
 
 def categorize(

--- a/gitpulse/ui/bulk_results.py
+++ b/gitpulse/ui/bulk_results.py
@@ -12,10 +12,7 @@ from textual.screen import ModalScreen
 from textual.widgets import DataTable, ProgressBar, Static
 from textual.containers import Container
 
-try:
-    from gitpulse.git_ops import RepoInfo
-except ImportError:
-    from git_ops import RepoInfo  # type: ignore[no-redef]
+from ..git_ops import RepoInfo
 
 
 class BulkResultsScreen(ModalScreen):

--- a/gitpulse/ui/digest_screen.py
+++ b/gitpulse/ui/digest_screen.py
@@ -16,14 +16,9 @@ from textual.screen import ModalScreen
 from textual.widgets import Static, Button
 from textual.containers import Container, ScrollableContainer, Horizontal
 
-try:
-    from gitpulse.digest import Digest, build_digest, render_markdown
-    from gitpulse.git_ops import RepoInfo
-    from gitpulse.utils import parse_since, relative_time
-except ImportError:
-    from digest import Digest, build_digest, render_markdown  # type: ignore
-    from git_ops import RepoInfo  # type: ignore
-    from utils import parse_since, relative_time  # type: ignore
+from ..digest import Digest, build_digest, render_markdown
+from ..git_ops import RepoInfo
+from ..utils import parse_since, relative_time
 
 
 class DigestScreen(ModalScreen):

--- a/gitpulse/ui/error_log.py
+++ b/gitpulse/ui/error_log.py
@@ -1,0 +1,94 @@
+"""
+error_log.py — Modal screen showing recorded error details.
+
+The app records raw error text into a capped ring buffer as operations fail.
+This screen is how the user actually reads it: without a view, a failure that
+affects one repo out of forty leaves no trace beyond a two-second toast.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+class ErrorLogScreen(ModalScreen[None]):
+    """Scrollable list of recorded errors, newest first."""
+
+    DEFAULT_CSS = """
+    ErrorLogScreen {
+        align: center middle;
+    }
+    #errorlog-box {
+        width: 96;
+        max-width: 90%;
+        height: auto;
+        max-height: 90%;
+        padding: 1 2;
+        background: #111827;
+        border: round #ef4444;
+    }
+    #errorlog-title {
+        width: 100%;
+        color: #d1d5db;
+        margin-bottom: 1;
+    }
+    #errorlog-body {
+        width: 100%;
+        height: auto;
+        max-height: 28;
+    }
+    .errorlog-row {
+        width: 100%;
+        height: auto;
+        color: #d1d5db;
+        margin-bottom: 1;
+    }
+    #errorlog-empty {
+        width: 100%;
+        height: auto;
+    }
+    #errorlog-hint {
+        width: 100%;
+        margin-top: 1;
+        border-top: solid #1f2937;
+        padding-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_log", "Close", id="errorlog.close", show=True),
+        Binding("q", "dismiss_log", "Close", id="errorlog.quit", show=False),
+    ]
+
+    def __init__(self, errors: list[str], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._errors = list(reversed(errors))  # newest first
+
+    def compose(self) -> ComposeResult:
+        count = len(self._errors)
+        label = "entry" if count == 1 else "entries"
+
+        with Vertical(id="errorlog-box"):
+            yield Static(f"[bold]Error log[/]  ·  {count} {label}", id="errorlog-title")
+            with VerticalScroll(id="errorlog-body"):
+                if not self._errors:
+                    yield Static(
+                        "[#6b7280]No errors recorded this session.[/]",
+                        id="errorlog-empty",
+                    )
+                for i, detail in enumerate(self._errors):
+                    # Error text is arbitrary (git stderr) and may contain
+                    # square brackets, so render it without markup parsing.
+                    yield Static(
+                        f"{i + 1:>3}  {detail}",
+                        classes="errorlog-row",
+                        markup=False,
+                    )
+            yield Static("[#6b7280]esc close[/]", id="errorlog-hint")
+
+    def action_dismiss_log(self) -> None:
+        self.dismiss(None)

--- a/gitpulse/ui/fleet_status.py
+++ b/gitpulse/ui/fleet_status.py
@@ -9,14 +9,21 @@ FilterRequested message so the sidebar can narrow to matching repos.
 from __future__ import annotations
 
 from textual.app import ComposeResult
+from textual.containers import Horizontal
 from textual.message import Message
-from textual.widget import Widget
 from textual.widgets import Static
 
-try:
-    from gitpulse.git_ops import RepoInfo, RepoStatus
-except ImportError:
-    from git_ops import RepoInfo, RepoStatus  # type: ignore[no-redef]
+from ..git_ops import RepoInfo, RepoStatus
+
+
+_CHIP_TOOLTIPS = {
+    "dirty": "Repos with uncommitted changes",
+    "behind": "Total commits behind upstream",
+    "ahead": "Repos with unpushed commits",
+    "stashes": "Total stash entries",
+    "stale": "Repos with stale branches",
+    "all": "Clear the filter",
+}
 
 
 class FleetChip(Static):
@@ -25,12 +32,15 @@ class FleetChip(Static):
     def __init__(self, category: str, **kwargs) -> None:
         super().__init__(**kwargs)
         self.category = category
+        # Labels are abbreviated to fit a narrow sidebar; the tooltip carries
+        # the full meaning so the strip stays discoverable.
+        self.tooltip = _CHIP_TOOLTIPS.get(category)
 
     def on_click(self) -> None:
         self.post_message(FleetStatus.FilterRequested(self.category))
 
 
-class FleetStatus(Widget):
+class FleetStatus(Horizontal):
     """
     Quiet single-row strip above the sidebar showing cross-repo counters.
 
@@ -50,7 +60,6 @@ class FleetStatus(Widget):
         self._active_filter: str = ""
 
     def compose(self) -> ComposeResult:
-        yield Static("fleet", id="fleet-label", markup=False)
         yield FleetChip("dirty",   id="chip-dirty")
         yield FleetChip("behind",  id="chip-behind")
         yield FleetChip("ahead",   id="chip-ahead")
@@ -59,11 +68,7 @@ class FleetStatus(Widget):
         yield FleetChip("all",     id="chip-all")
 
     def on_mount(self) -> None:
-        self._set_chip("chip-dirty",   "dirty",  0, "#f59e0b")
-        self._set_chip("chip-behind",  "behind", 0, "#ef4444")
-        self._set_chip("chip-ahead",   "ahead",  0, "#22c55e")
-        self._set_chip("chip-stashes", "stash",  0, "#8b5cf6")
-        self._set_chip("chip-stale",   "stale",  0, "#6b7280")
+        self.update_counters([])
         self.query_one("#chip-all", FleetChip).update("[#6b7280]all[/]")
 
     def update_counters(self, repos: list[RepoInfo]) -> None:
@@ -74,11 +79,13 @@ class FleetStatus(Widget):
         total_stashes = sum(r.stash_count for r in repos)
         n_stale       = sum(1 for r in repos if r.has_stale_branches)
 
-        self._set_chip("chip-dirty",   "dirty",  n_dirty,       "#f59e0b")
-        self._set_chip("chip-behind",  "behind", total_behind,  "#ef4444")
-        self._set_chip("chip-ahead",   "ahead",  n_ahead,       "#22c55e")
-        self._set_chip("chip-stashes", "stash",  total_stashes, "#8b5cf6")
-        self._set_chip("chip-stale",   "stale",  n_stale,       "#6b7280")
+        # Short labels: six chips must fit a sidebar of ~31 usable columns.
+        # Tooltips carry the full meaning of each abbreviation.
+        self._set_chip("chip-dirty",   "dirty", n_dirty,       "#f59e0b")
+        self._set_chip("chip-behind",  "↓",     total_behind,  "#ef4444")
+        self._set_chip("chip-ahead",   "↑",     n_ahead,       "#22c55e")
+        self._set_chip("chip-stashes", "stsh",  total_stashes, "#8b5cf6")
+        self._set_chip("chip-stale",   "stl",   n_stale,       "#6b7280")
 
     def set_active_filter(self, category: str) -> None:
         """Highlight the active filter chip and clear the others."""

--- a/gitpulse/ui/help_modal.py
+++ b/gitpulse/ui/help_modal.py
@@ -16,11 +16,13 @@ from textual.containers import Container, ScrollableContainer
 _SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
     ("Global", [
         ("/", "Search / filter repos"),
+        ("j / k", "Move down / up the repo list"),
         ("r", "Refresh — rescan all repos"),
         ("w", "Toggle watch mode"),
         ("d", "Activity digest"),
         (":", "Bulk action palette"),
         ("b", "Stale-branch cleanup"),
+        ("e", "Error log"),
         ("[ ]", "Previous / next tab"),
         ("?", "This help"),
         ("q", "Quit"),

--- a/gitpulse/ui/sidebar.py
+++ b/gitpulse/ui/sidebar.py
@@ -16,19 +16,27 @@ from textual.app import ComposeResult
 from textual.message import Message
 from textual.widgets import Static, ListView, ListItem, Input
 
-try:
-    from gitpulse.git_ops import RepoInfo, RepoStatus
-except ImportError:
-    from git_ops import RepoInfo, RepoStatus  # type: ignore[no-redef]
+from ..git_ops import RepoInfo, RepoStatus
 
 
 # ---------------------------------------------------------------------------
-# Column layout — character widths, must match the header row below
+# Column layout — widths are computed from the sidebar's actual width by
+# column_widths(); the header and the rows both derive from it so they cannot
+# drift out of alignment.
 # ---------------------------------------------------------------------------
 
-_W_REPO = 16
-_W_BRANCH = 15
 _W_CHANGES = 3
+
+# Fixed overhead per row: gutter marker + space, space after repo, space after
+# branch, the change-count column, space, status dot.
+_ROW_CHROME = 2 + 1 + 1 + _W_CHANGES + 1 + 1
+
+# Floors — below these the columns stop shrinking and truncate instead.
+_MIN_REPO = 10
+_MIN_BRANCH = 8
+
+# Fallback used before the widget knows its own size.
+_DEFAULT_AVAIL = 44
 
 # Palette
 _TEXT = "#d1d5db"
@@ -41,9 +49,28 @@ _RED = "#ef4444"
 
 def _fit(value: str, width: int) -> str:
     """Truncate with an ellipsis or left-pad *value* to exactly *width* chars."""
+    if width <= 0:
+        return ""
     if len(value) > width:
+        if width == 1:
+            return "…"
         return value[: width - 1] + "…"
     return value.ljust(width)
+
+
+def column_widths(avail: int) -> tuple[int, int]:
+    """Split *avail* columns between the repo-name and branch columns.
+
+    Widths are derived from the sidebar's real width rather than hardcoded, so
+    the row fills the panel at any size instead of truncating at a fixed 16/15
+    while the container flexes.
+    """
+    flex = avail - _ROW_CHROME
+    if flex < _MIN_REPO + _MIN_BRANCH:
+        return _MIN_REPO, _MIN_BRANCH
+    w_repo = max(_MIN_REPO, int(flex * 0.55))
+    w_branch = max(_MIN_BRANCH, flex - w_repo)
+    return w_repo, w_branch
 
 
 def _status_dot(info: RepoInfo) -> tuple[str, str]:
@@ -60,13 +87,14 @@ def _status_dot(info: RepoInfo) -> tuple[str, str]:
     return "●", _RED
 
 
-def column_header() -> Text:
+def column_header(avail: int = _DEFAULT_AVAIL) -> Text:
     """Build the aligned column-header row shown above the list."""
+    w_repo, w_branch = column_widths(avail)
     t = Text(no_wrap=True, overflow="ellipsis", style=_MUTED)
     t.append("  ")  # gutter + space
-    t.append(_fit("Repository", _W_REPO))
+    t.append(_fit("Repository", w_repo))
     t.append(" ")
-    t.append(_fit("Branch", _W_BRANCH))
+    t.append(_fit("Branch", w_branch))
     t.append(" ")
     t.append("Δ".rjust(_W_CHANGES))
     t.append(" ")
@@ -81,23 +109,31 @@ def column_header() -> Text:
 class RepoListItem(ListItem):
     """A single-line row in the sidebar representing one git repository."""
 
-    def __init__(self, repo_info: RepoInfo, selected: bool = False, **kwargs) -> None:
+    def __init__(
+        self,
+        repo_info: RepoInfo,
+        selected: bool = False,
+        avail: int = _DEFAULT_AVAIL,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.repo_info = repo_info
         self._selected = selected
+        self._avail = avail
 
     def compose(self) -> ComposeResult:
         info = self.repo_info
+        w_repo, w_branch = column_widths(self._avail)
         t = Text(no_wrap=True, overflow="ellipsis")
 
         # Gutter: multi-select marker
         t.append("•" if self._selected else " ", style=_ACCENT)
         t.append(" ")
         # Repository
-        t.append(_fit(info.name, _W_REPO), style=f"bold {_TEXT}")
+        t.append(_fit(info.name, w_repo), style=f"bold {_TEXT}")
         t.append(" ")
         # Branch
-        t.append(_fit(info.branch, _W_BRANCH), style=_ACCENT)
+        t.append(_fit(info.branch, w_branch), style=_ACCENT)
         t.append(" ")
         # Changes count — only show the number when there is something to show
         count = info.modified_count
@@ -147,6 +183,7 @@ class RepoSidebar(Static):
         super().__init__(**kwargs)
         self._selected: set[Path] = set()
         self._current_repos: list[RepoInfo] = []
+        self._avail: int = _DEFAULT_AVAIL  # Sidebar width, updated on resize
 
     # ── Multi-select API ────────────────────────────────────────────────
 
@@ -185,8 +222,22 @@ class RepoSidebar(Static):
     def compose(self) -> ComposeResult:
         yield Static("FLEET", id="sidebar-title", markup=False)
         yield Input(placeholder="Filter repos...", id="search-input")
-        yield Static(column_header(), id="repo-list-header")
+        yield Static(column_header(self._avail), id="repo-list-header")
         yield ListView(id="repo-list")
+
+    def on_resize(self, event) -> None:
+        """Recompute column widths and rebuild rows when the sidebar resizes."""
+        avail = max(int(event.size.width), _ROW_CHROME + _MIN_REPO + _MIN_BRANCH)
+        if avail == self._avail:
+            return
+        self._avail = avail
+        self.query_one("#repo-list-header", Static).update(column_header(avail))
+        if self._current_repos:
+            lv: ListView = self.query_one("#repo-list", ListView)
+            keep = lv.index
+            self.populate(self._current_repos)
+            if keep is not None and keep < len(self._current_repos):
+                lv.index = keep
 
     def update_header(
         self,
@@ -226,7 +277,9 @@ class RepoSidebar(Static):
 
         target_index = 0
         for i, info in enumerate(repos):
-            list_view.append(RepoListItem(info, selected=info.path in self._selected))
+            list_view.append(RepoListItem(
+                info, selected=info.path in self._selected, avail=self._avail,
+            ))
             if keep_path is not None and info.path == keep_path:
                 target_index = i
 
@@ -242,9 +295,19 @@ class RepoSidebar(Static):
                 return
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
-        """Forward the highlight event as a RepoSelected message."""
-        if event.item is not None and isinstance(event.item, RepoListItem):
-            self.post_message(self.RepoSelected(event.item.repo_info))
+        """Forward the highlight event as a RepoSelected message.
+
+        ``populate`` clears and refills the ListView, and those mutations queue
+        Highlighted events that arrive *after* it returns. Such an event can
+        reference a row from the previous list, which would clobber the
+        selection populate just restored — so ignore any item that is no longer
+        part of the current list.
+        """
+        if not isinstance(event.item, RepoListItem):
+            return
+        if event.item.repo_info.path not in {r.path for r in self._current_repos}:
+            return
+        self.post_message(self.RepoSelected(event.item.repo_info))
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Forward search input changes."""

--- a/gitpulse/ui/stale_screen.py
+++ b/gitpulse/ui/stale_screen.py
@@ -15,18 +15,11 @@ from textual.screen import ModalScreen
 from textual.widgets import DataTable, Input, Static, Button, TabbedContent, TabPane
 from textual.containers import Container, Vertical, Horizontal
 
-try:
-    from gitpulse.git_ops import BranchDetail, delete_branch
-    from gitpulse.stale import gather_all_repos, categorize
-    from gitpulse.parallel import run_parallel
-    from gitpulse.utils import relative_time
-    from gitpulse.ui.confirm_modal import TypedConfirmModal
-except ImportError:
-    from git_ops import BranchDetail, delete_branch  # type: ignore
-    from stale import gather_all_repos, categorize  # type: ignore
-    from parallel import run_parallel  # type: ignore
-    from utils import relative_time  # type: ignore
-    from ui.confirm_modal import TypedConfirmModal  # type: ignore
+from ..git_ops import BranchDetail, delete_branch
+from ..stale import gather_all_repos, categorize
+from ..parallel import run_parallel
+from ..utils import relative_time
+from .confirm_modal import TypedConfirmModal
 
 
 class StaleScreen(ModalScreen):

--- a/gitpulse/ui/styles.tcss
+++ b/gitpulse/ui/styles.tcss
@@ -30,10 +30,13 @@ Screen {
     height: 1fr;
 }
 
+/* Proportional so the repo/branch columns gain room on wide terminals and
+   stay readable on narrow ones; sidebar.py derives its column widths from
+   the resulting width at runtime. */
 #sidebar-column {
-    width: 46;
-    min-width: 38;
-    max-width: 54;
+    width: 32%;
+    min-width: 34;
+    max-width: 64;
     background: #111827;
     border-right: solid #1f2937;
 }
@@ -540,24 +543,23 @@ Button.-error {
 }
 
 /* ---------- Fleet status strip ---------- */
+/* Six counters must fit a sidebar that can be as narrow as ~31 columns, so
+   labels are abbreviated (tooltips carry the full meaning) and chips size to
+   their own content with a single separating space. */
 FleetStatus {
     height: 1;
     background: #111827;
     layout: horizontal;
     align: left middle;
-    padding: 0 1;
-}
-
-FleetStatus > Static#fleet-label {
-    width: auto;
-    color: #6b7280;
-    margin-right: 1;
+    padding: 0;
+    overflow: hidden;
 }
 
 FleetChip {
     width: auto;
     height: 1;
-    padding: 0 1;
+    padding: 0;
+    margin-right: 1;
     color: #6b7280;
 }
 

--- a/gitpulse/ui/summary_cards.py
+++ b/gitpulse/ui/summary_cards.py
@@ -11,10 +11,7 @@ from __future__ import annotations
 from textual.app import ComposeResult
 from textual.widgets import Static
 
-try:
-    from gitpulse.git_ops import RepoInfo, RepoStatus, StashEntry
-except ImportError:
-    from git_ops import RepoInfo, RepoStatus, StashEntry  # type: ignore[no-redef]
+from ..git_ops import RepoInfo, RepoStatus, StashEntry
 
 _TEXT = "#d1d5db"
 _MUTED = "#6b7280"

--- a/gitpulse/ui/tabs.py
+++ b/gitpulse/ui/tabs.py
@@ -40,38 +40,21 @@ from textual.widgets import (
 )
 from textual.containers import Container, Horizontal, ScrollableContainer, Vertical
 
-try:
-    from gitpulse.git_ops import (
-        get_status, get_commits, get_branches,
-        get_stashes, get_remotes, get_tags, get_file_tree,
-        get_changed_files, get_file_diff, get_commit_diff,
-        stage_files, unstage_files, stage_all, unstage_all, commit_changes,
-        create_branch, delete_branch,
-        git_fetch, git_pull, git_push,
-        stash_create, stash_pop,
-        get_commit_graph, get_file_contents, get_tracked_files,
-        is_dirty, classify_error,
-        BranchInfo, RepoInfo,
-    )
-    from gitpulse.utils import relative_time
-    from gitpulse.ui.summary_cards import SummaryCards
-    from gitpulse.ui.confirm_modal import ConfirmModal, TypedConfirmModal
-except ImportError:
-    from git_ops import (  # type: ignore[no-redef]
-        get_status, get_commits, get_branches,
-        get_stashes, get_remotes, get_tags, get_file_tree,
-        get_changed_files, get_file_diff, get_commit_diff,
-        stage_files, unstage_files, stage_all, unstage_all, commit_changes,
-        create_branch, delete_branch,
-        git_fetch, git_pull, git_push,
-        stash_create, stash_pop,
-        get_commit_graph, get_file_contents, get_tracked_files,
-        is_dirty, classify_error,
-        BranchInfo, RepoInfo,
-    )
-    from utils import relative_time  # type: ignore[no-redef]
-    from ui.summary_cards import SummaryCards  # type: ignore[no-redef]
-    from ui.confirm_modal import ConfirmModal, TypedConfirmModal  # type: ignore[no-redef]
+from ..git_ops import (
+    get_status, get_commits, get_branches,
+    get_stashes, get_remotes, get_tags, get_file_tree,
+    get_changed_files, get_file_diff, get_commit_diff,
+    stage_files, unstage_files, stage_all, unstage_all, commit_changes,
+    create_branch, delete_branch,
+    git_fetch, git_pull, git_push,
+    stash_create, stash_pop,
+    get_commit_graph, get_file_contents, get_tracked_files,
+    is_dirty, classify_error,
+    BranchInfo, RepoInfo,
+)
+from ..utils import relative_time
+from .summary_cards import SummaryCards
+from .confirm_modal import ConfirmModal, TypedConfirmModal
 
 
 def _record_app_error(app, detail: str) -> None:
@@ -1077,31 +1060,48 @@ class MainPanel(Widget):
 
         self.query_one("#summary-cards", SummaryCards).update_cards(info, stashes)
 
-        self._fill_ws_list("#staged-list", fs.staged, "staged", "No changes staged")
-        self._fill_ws_list("#unstaged-list", fs.unstaged, "unstaged", "No unstaged changes")
-        self._fill_ws_list("#untracked-list", fs.untracked, "untracked", "No untracked files")
+        self._fill_ws_list(
+            "#staged-list", fs.staged, "staged",
+            "No changes staged", "Press s on a file to stage it",
+        )
+        self._fill_ws_list(
+            "#unstaged-list", fs.unstaged, "unstaged",
+            "No unstaged changes", "Tracked files match the index",
+        )
+        self._fill_ws_list(
+            "#untracked-list", fs.untracked, "untracked",
+            "No untracked files", "Everything here is tracked by git",
+        )
         self._fill_stash_list(stashes)
 
         # Right-hand panels — use the data already fetched in the worker.
         self._apply_status_panels(data)
 
-    def _empty_row(self, message: str) -> ListItem:
-        """Build a centered empty-state row for an empty workspace list."""
-        item = ListItem(Static(
-            f"[#22c55e]✓[/]\n[#d1d5db]{message}[/]\n"
-            f"[#6b7280]Working tree is clean[/]",
-            markup=True,
-        ))
+    def _empty_row(self, message: str, hint: str = "") -> ListItem:
+        """Build a centered empty-state row for an empty workspace list.
+
+        *hint* describes this list only. It must not claim the whole tree is
+        clean — an empty Staged list says nothing about untracked files.
+        """
+        body = f"[#22c55e]✓[/]\n[#d1d5db]{message}[/]"
+        if hint:
+            body += f"\n[#6b7280]{hint}[/]"
+        item = ListItem(Static(body, markup=True))
         item.add_class("empty-row")
         return item
 
     def _fill_ws_list(
-        self, list_id: str, files: list[str], status: str, empty_msg: str
+        self,
+        list_id: str,
+        files: list[str],
+        status: str,
+        empty_msg: str,
+        empty_hint: str = "",
     ) -> None:
         lv: ListView = self.query_one(list_id, ListView)
         lv.clear()
         if not files:
-            lv.append(self._empty_row(empty_msg))
+            lv.append(self._empty_row(empty_msg, empty_hint))
             return
         for f in files:
             lv.append(StatusFileItem(f, status))
@@ -1110,7 +1110,7 @@ class MainPanel(Widget):
         lv: ListView = self.query_one("#stashes-list", ListView)
         lv.clear()
         if not stashes:
-            lv.append(self._empty_row("No stashes"))
+            lv.append(self._empty_row("No stashes", "Press z to stash your changes"))
             return
         for s in stashes:
             t = Text(overflow="ellipsis", no_wrap=True)

--- a/gitpulse/watcher.py
+++ b/gitpulse/watcher.py
@@ -14,10 +14,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-try:
-    from gitpulse.git_ops import RepoInfo
-except ImportError:
-    from git_ops import RepoInfo  # type: ignore[no-redef]
+from .git_ops import RepoInfo
 
 
 def repo_signature(repo_path: Path) -> tuple[float, float, float, float]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,16 +6,50 @@ build-backend = "setuptools.build_meta"
 name = "gitpulse-tui"
 version = "1.2.14"
 description = "Git Repo Dashboard TUI — live status, commits, diffs, and branches in your terminal"
+readme = "README.md"
+license = "AGPL-3.0-or-later"
+license-files = ["LICENSE"]
+authors = [{ name = "lebiraja" }]
 requires-python = ">=3.10"
+keywords = ["git", "tui", "terminal", "dashboard", "cli", "textual", "monorepo", "multi-repo"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Version Control :: Git",
+    "Topic :: Utilities",
+]
+# Upper bounds: Textual and Rich both make breaking changes across majors, and
+# GitPulse leans on a wide surface of both (workers, ModalScreen, ListView
+# internals, a large .tcss file). The scheduled "latest deps" CI job is what
+# keeps these ceilings from going stale.
 dependencies = [
-    "textual>=0.50.0",
-    "rich>=13.0.0",
-    "gitpython>=3.1.0",
+    "textual>=0.50.0,<9.0",
+    "rich>=13.0.0,<16.0",
+    "gitpython>=3.1.0,<4.0",
     "tomli>=2.0.0; python_version<'3.11'",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/lebiraja/gitpulse"
+Source = "https://github.com/lebiraja/gitpulse"
+Issues = "https://github.com/lebiraja/gitpulse/issues"
+
 [project.scripts]
-gitpulse = "gitpulse.main:main"
+gitpulse = "gitpulse.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -23,3 +57,7 @@ include = ["gitpulse*"]
 
 [tool.setuptools.package-data]
 gitpulse = ["ui/*.tcss"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,74 @@
+"""Shared fixtures — real git repositories on disk, no mocking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from git import Repo
+
+
+def _init(path: Path) -> Repo:
+    """Initialise a repo with a deterministic identity and one commit."""
+    repo = Repo.init(path, initial_branch="main")
+    with repo.config_writer() as cw:
+        cw.set_value("user", "email", "test@example.com")
+        cw.set_value("user", "name", "Test User")
+        cw.set_value("commit", "gpgsign", "false")
+    (path / "README.md").write_text("# test\n")
+    repo.index.add(["README.md"])
+    repo.index.commit("initial commit")
+    return repo
+
+
+@pytest.fixture
+def repo_path(tmp_path) -> Path:
+    """A clean git repo containing a single commit."""
+    path = tmp_path / "solo"
+    path.mkdir()
+    _init(path)
+    return path
+
+
+@pytest.fixture
+def repo(repo_path) -> Repo:
+    """The GitPython handle for :func:`repo_path`."""
+    return Repo(repo_path)
+
+
+@pytest.fixture
+def remote_repo(tmp_path) -> Path:
+    """A bare repo usable as a push target — no network required."""
+    bare = tmp_path / "origin.git"
+    Repo.init(bare, bare=True)
+    return bare
+
+
+@pytest.fixture
+def fleet(tmp_path) -> Path:
+    """A root directory containing three repos in differing states.
+
+    - ``clean``     — nothing outstanding
+    - ``dirty``     — one untracked file
+    - ``committed`` — one extra commit, staged file removed
+    """
+    root = tmp_path / "fleet"
+    root.mkdir()
+
+    clean = root / "clean"
+    clean.mkdir()
+    _init(clean)
+
+    dirty = root / "dirty"
+    dirty.mkdir()
+    _init(dirty)
+    (dirty / "scratch.txt").write_text("uncommitted\n")
+
+    committed = root / "committed"
+    committed.mkdir()
+    r = _init(committed)
+    (committed / "second.txt").write_text("more\n")
+    r.index.add(["second.txt"])
+    r.index.commit("second commit")
+
+    return root

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,135 @@
+"""Coverage for the public library surface (gitpulse.api)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from gitpulse.api import (
+    SCHEMA_VERSION,
+    fleet_to_dict,
+    is_unreadable,
+    repo_state,
+    repo_to_dict,
+    scan_fleet,
+    scan_fleet_detailed,
+)
+
+
+class TestImportIsolation:
+    def test_api_does_not_import_textual(self):
+        """gitpulse.api must be importable without dragging in the TUI."""
+        # Arrange
+        code = (
+            "import sys, gitpulse.api; "
+            "bad = [m for m in sys.modules if m.split('.')[0] == 'textual']; "
+            "sys.exit(1 if bad else 0)"
+        )
+
+        # Act
+        result = subprocess.run([sys.executable, "-c", code])
+
+        # Assert
+        assert result.returncode == 0, "gitpulse.api pulled in textual"
+
+
+class TestScanFleet:
+    def test_finds_every_repo(self, fleet):
+        # Act
+        repos = scan_fleet(fleet)
+
+        # Assert
+        assert {r.name for r in repos} == {"clean", "dirty", "committed"}
+
+    def test_sorted_by_most_recent_commit_first(self, fleet):
+        # Act
+        repos = scan_fleet(fleet)
+
+        # Assert
+        timestamps = [r.last_commit_ts for r in repos]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_missing_root_raises(self, tmp_path):
+        # Act / Assert
+        with pytest.raises(NotADirectoryError):
+            scan_fleet(tmp_path / "nope")
+
+    def test_detailed_reports_no_errors_for_healthy_fleet(self, fleet):
+        # Act
+        result = scan_fleet_detailed(fleet)
+
+        # Assert
+        assert result.errors == []
+        assert len(result) == 3
+
+    def test_result_is_iterable(self, fleet):
+        # Act
+        result = scan_fleet_detailed(fleet)
+
+        # Assert
+        assert [r.name for r in result] == [r.name for r in result.repos]
+
+
+class TestRepoState:
+    def test_returns_info_for_one_repo(self, repo_path):
+        # Act
+        info = repo_state(repo_path)
+
+        # Assert
+        assert info.name == "solo"
+        assert info.branch == "main"
+
+
+class TestSerialization:
+    def test_status_is_a_lowercase_string(self, repo_path):
+        # Act
+        payload = repo_to_dict(repo_state(repo_path))
+
+        # Assert
+        assert payload["status"] == "clean"
+        assert payload["readable"] is True
+
+    def test_last_commit_carries_epoch_and_iso(self, repo_path):
+        # Act
+        payload = repo_to_dict(repo_state(repo_path))
+
+        # Assert
+        assert payload["last_commit"]["ts"] > 0
+        assert payload["last_commit"]["iso"].endswith("+00:00")
+
+    def test_envelope_has_schema_version_and_counts(self, fleet):
+        # Act
+        payload = fleet_to_dict(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert payload["repo_count"] == 3
+        assert payload["errors"] == []
+
+    def test_envelope_is_json_serialisable(self, fleet):
+        # Act
+        payload = fleet_to_dict(scan_fleet_detailed(fleet))
+
+        # Assert — must not raise
+        assert json.loads(json.dumps(payload))["repo_count"] == 3
+
+    def test_unreadable_repo_is_not_reported_as_clean(self, tmp_path):
+        """A directory git cannot read must never look like a clean repo."""
+        # Arrange — a .git that is not a valid repository
+        broken = tmp_path / "broken"
+        (broken / ".git").mkdir(parents=True)
+        (broken / ".git" / "config").write_text("garbage\n")
+
+        # Act
+        payload = repo_to_dict(repo_state(broken))
+
+        # Assert
+        assert payload["status"] == "unreadable"
+        assert payload["readable"] is False
+
+    def test_is_unreadable_false_for_real_repo(self, repo_path):
+        # Act / Assert
+        assert is_unreadable(repo_state(repo_path)) is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,148 @@
+"""
+End-to-end coverage for the non-interactive CLI surface.
+
+Each test runs the real console entry point in a subprocess so it exercises
+argument parsing, stdout formatting, and exit codes exactly as an agent
+shelling out would experience them.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def run_cli(*args, expect_success: bool = True) -> subprocess.CompletedProcess:
+    """Invoke `python -m gitpulse ...` and return the completed process."""
+    result = subprocess.run(
+        [sys.executable, "-m", "gitpulse", *args],
+        capture_output=True,
+        text=True,
+    )
+    if expect_success:
+        assert result.returncode == 0, result.stderr
+    return result
+
+
+class TestScanJson:
+    def test_emits_valid_json(self, fleet):
+        # Act
+        result = run_cli("scan", "--root", str(fleet), "--json")
+
+        # Assert
+        payload = json.loads(result.stdout)
+        assert payload["repo_count"] == 3
+
+    def test_stdout_contains_only_json(self, fleet):
+        """Nothing may pollute stdout — consumers pipe it straight to a parser."""
+        # Act
+        result = run_cli("scan", "--root", str(fleet), "--json")
+
+        # Assert
+        assert result.stdout.lstrip().startswith("{")
+        json.loads(result.stdout)
+
+    def test_dirty_filter_narrows_results(self, fleet):
+        # Act
+        result = run_cli("scan", "--root", str(fleet), "--json", "--dirty")
+
+        # Assert
+        payload = json.loads(result.stdout)
+        assert [r["name"] for r in payload["repos"]] == ["dirty"]
+
+    def test_repo_count_reflects_the_filter(self, fleet):
+        # Act
+        result = run_cli("scan", "--root", str(fleet), "--json", "--dirty")
+
+        # Assert
+        assert json.loads(result.stdout)["repo_count"] == 1
+
+    def test_ndjson_emits_one_object_per_line(self, fleet):
+        # Act
+        result = run_cli("scan", "--root", str(fleet), "--ndjson")
+
+        # Assert
+        lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+        assert len(lines) == 3
+        assert all(json.loads(ln)["name"] for ln in lines)
+
+    def test_json_and_ndjson_are_mutually_exclusive(self, fleet):
+        # Act
+        result = run_cli(
+            "scan", "--root", str(fleet), "--json", "--ndjson",
+            expect_success=False,
+        )
+
+        # Assert
+        assert result.returncode != 0
+        assert "not allowed with" in result.stderr
+
+    def test_missing_root_exits_nonzero(self, tmp_path):
+        # Act
+        result = run_cli(
+            "scan", "--root", str(tmp_path / "absent"), "--json",
+            expect_success=False,
+        )
+
+        # Assert
+        assert result.returncode == 1
+        assert "Error" in result.stderr
+
+
+class TestContext:
+    def test_renders_markdown_headings(self, fleet):
+        # Act
+        result = run_cli("context", "--root", str(fleet))
+
+        # Assert
+        assert result.stdout.startswith("# Fleet state")
+        assert "## Needs attention" in result.stdout
+
+    def test_dirty_repo_is_listed_as_needing_attention(self, fleet):
+        # Act
+        result = run_cli("context", "--root", str(fleet))
+
+        # Assert
+        attention = result.stdout.split("## Needs attention")[1]
+        assert "dirty" in attention
+
+
+class TestDigest:
+    def test_renders_a_digest(self, fleet):
+        # Act
+        result = run_cli(
+            "digest", "--root", str(fleet),
+            "--since", "7d", "--author", "test@example.com",
+        )
+
+        # Assert
+        assert "Activity digest" in result.stdout
+
+    def test_bad_time_spec_exits_nonzero(self, fleet):
+        # Act
+        result = run_cli(
+            "digest", "--root", str(fleet), "--since", "not-a-window",
+            expect_success=False,
+        )
+
+        # Assert
+        assert result.returncode == 1
+        assert "Unrecognised time spec" in result.stderr
+
+
+class TestTopLevel:
+    def test_version_flag_reports_version(self):
+        # Act
+        result = run_cli("--version")
+
+        # Assert
+        assert result.stdout.startswith("gitpulse ")
+
+    def test_help_lists_the_subcommands(self):
+        # Act
+        result = run_cli("--help")
+
+        # Assert
+        for name in ("scan", "context", "digest"):
+            assert name in result.stdout

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,76 @@
+"""Coverage for the Markdown context pack (gitpulse.context)."""
+
+from __future__ import annotations
+
+from gitpulse.api import scan_fleet_detailed
+from gitpulse.context import render_context
+
+
+class TestRenderContext:
+    def test_starts_with_a_timestamped_heading(self, fleet):
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert out.startswith("# Fleet state — ")
+
+    def test_reports_the_root_and_repo_count(self, fleet):
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert str(fleet) in out
+        assert "3 repos" in out
+
+    def test_dirty_repo_appears_under_needs_attention(self, fleet):
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        section = out.split("## Needs attention")[1]
+        assert "dirty" in section
+
+    def test_clean_repos_are_collapsed_into_a_name_list(self, fleet):
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert "## Clean and synced" in out
+
+    def test_max_repos_truncates_with_a_note(self, fleet):
+        # Act — a cap below the number of attention repos
+        out = render_context(scan_fleet_detailed(fleet), max_repos=0)
+
+        # Assert
+        assert "more" in out
+
+    def test_output_ends_with_a_single_newline(self, fleet):
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert out.endswith("\n")
+        assert not out.endswith("\n\n")
+
+    def test_unreadable_repo_is_flagged_not_counted_clean(self, tmp_path):
+        """An unreadable repo must never be summarised as clean."""
+        # Arrange
+        root = tmp_path / "fleet"
+        broken = root / "broken"
+        (broken / ".git").mkdir(parents=True)
+        (broken / ".git" / "config").write_text("garbage\n")
+
+        # Act
+        out = render_context(scan_fleet_detailed(root))
+
+        # Assert
+        assert "## Could not be read" in out
+        assert "unknown, not clean" in out
+
+    def test_no_markup_leaks_into_the_output(self, fleet):
+        """Output is pasted into prompts — it must be plain Markdown."""
+        # Act
+        out = render_context(scan_fleet_detailed(fleet))
+
+        # Assert
+        assert "\x1b[" not in out

--- a/tests/test_git_ops_writes.py
+++ b/tests/test_git_ops_writes.py
@@ -1,0 +1,306 @@
+"""
+Coverage for the mutating half of git_ops — the operations the TUI can fan out
+across an entire fleet at once, and which previously had no direct tests.
+
+Every test runs against a real repository on disk; git_push targets a local
+bare repo so the code path is exercised without touching the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+from git import Repo
+
+from gitpulse.git_ops import (
+    RepoStatus,
+    commit_changes,
+    create_branch,
+    delete_branch,
+    get_branches,
+    get_repo_info,
+    get_status,
+    git_push,
+    is_dirty,
+    stage_all,
+    stage_files,
+    stash_create,
+    stash_pop,
+    unstage_all,
+    unstage_files,
+)
+
+
+class TestStaging:
+    def test_stage_files_moves_file_to_staged(self, repo_path):
+        # Arrange
+        (repo_path / "new.txt").write_text("hello\n")
+
+        # Act
+        stage_files(repo_path, ["new.txt"])
+
+        # Assert
+        status = get_status(repo_path)
+        assert "new.txt" in status.staged
+        assert "new.txt" not in status.untracked
+
+    def test_unstage_files_returns_file_to_untracked(self, repo_path):
+        # Arrange
+        (repo_path / "new.txt").write_text("hello\n")
+        stage_files(repo_path, ["new.txt"])
+
+        # Act
+        unstage_files(repo_path, ["new.txt"])
+
+        # Assert
+        status = get_status(repo_path)
+        assert "new.txt" not in status.staged
+
+    def test_stage_all_stages_every_change(self, repo_path):
+        # Arrange
+        (repo_path / "a.txt").write_text("a\n")
+        (repo_path / "b.txt").write_text("b\n")
+
+        # Act
+        stage_all(repo_path)
+
+        # Assert
+        status = get_status(repo_path)
+        assert {"a.txt", "b.txt"} <= set(status.staged)
+
+    def test_unstage_all_clears_the_index(self, repo_path):
+        # Arrange
+        (repo_path / "a.txt").write_text("a\n")
+        stage_all(repo_path)
+
+        # Act
+        unstage_all(repo_path)
+
+        # Assert
+        assert get_status(repo_path).staged == []
+
+
+class TestCommit:
+    def test_commit_changes_creates_a_commit(self, repo_path, repo):
+        # Arrange
+        before = len(list(repo.iter_commits()))
+        (repo_path / "feature.txt").write_text("work\n")
+        stage_all(repo_path)
+
+        # Act
+        commit_changes(repo_path, "add feature")
+
+        # Assert
+        commits = list(Repo(repo_path).iter_commits())
+        assert len(commits) == before + 1
+        assert commits[0].message.strip() == "add feature"
+
+    def test_commit_changes_leaves_tree_clean(self, repo_path):
+        # Arrange
+        (repo_path / "feature.txt").write_text("work\n")
+        stage_all(repo_path)
+
+        # Act
+        commit_changes(repo_path, "add feature")
+
+        # Assert
+        assert get_repo_info(repo_path).status == RepoStatus.CLEAN
+
+    def test_commit_with_nothing_staged_does_not_add_a_commit(self, repo_path, repo):
+        # Arrange
+        before = len(list(repo.iter_commits()))
+
+        # Act
+        commit_changes(repo_path, "empty")
+
+        # Assert
+        assert len(list(Repo(repo_path).iter_commits())) == before
+
+
+class TestBranches:
+    def test_create_branch_appears_in_listing(self, repo_path):
+        # Act
+        create_branch(repo_path, "feature/x", checkout=False)
+
+        # Assert
+        assert "feature/x" in {b.name for b in get_branches(repo_path)}
+
+    def test_create_branch_with_checkout_switches_head(self, repo_path):
+        # Act
+        create_branch(repo_path, "feature/y", checkout=True)
+
+        # Assert
+        assert get_repo_info(repo_path).branch == "feature/y"
+
+    def test_delete_branch_removes_it(self, repo_path):
+        # Arrange
+        create_branch(repo_path, "feature/z", checkout=False)
+
+        # Act
+        delete_branch(repo_path, "feature/z", force=True)
+
+        # Assert
+        assert "feature/z" not in {b.name for b in get_branches(repo_path)}
+
+    def test_delete_current_branch_is_rejected(self, repo_path):
+        # Arrange
+        current = get_repo_info(repo_path).branch
+
+        # Act
+        delete_branch(repo_path, current, force=True)
+
+        # Assert — git refuses to delete the checked-out branch
+        assert current in {b.name for b in get_branches(repo_path)}
+
+
+class TestStash:
+    def test_stash_create_clears_the_working_tree(self, repo_path):
+        # Arrange
+        (repo_path / "README.md").write_text("# modified\n")
+
+        # Act
+        stash_create(repo_path, "wip")
+
+        # Assert
+        assert get_repo_info(repo_path).status == RepoStatus.CLEAN
+
+    def test_stash_pop_restores_the_change(self, repo_path):
+        # Arrange
+        (repo_path / "README.md").write_text("# modified\n")
+        stash_create(repo_path, "wip")
+
+        # Act
+        stash_pop(repo_path)
+
+        # Assert
+        assert (repo_path / "README.md").read_text() == "# modified\n"
+
+    def test_stash_create_increments_stash_count(self, repo_path):
+        # Arrange
+        (repo_path / "README.md").write_text("# modified\n")
+
+        # Act
+        stash_create(repo_path, "wip")
+
+        # Assert
+        assert get_repo_info(repo_path).stash_count == 1
+
+
+class TestPush:
+    def test_git_push_updates_the_remote(self, repo_path, remote_repo):
+        # Arrange
+        repo = Repo(repo_path)
+        repo.create_remote("origin", str(remote_repo))
+        repo.git.push("--set-upstream", "origin", "main")
+        (repo_path / "later.txt").write_text("later\n")
+        stage_all(repo_path)
+        commit_changes(repo_path, "later work")
+
+        # Act
+        git_push(repo_path)
+
+        # Assert — read the pushed branch directly; a bare repo's default HEAD
+        # may point at a branch name the working repo never used.
+        pushed = Repo(remote_repo).refs["main"].commit
+        assert pushed.message.strip() == "later work"
+
+    def test_repo_is_ahead_before_push(self, repo_path, remote_repo):
+        # Arrange
+        repo = Repo(repo_path)
+        repo.create_remote("origin", str(remote_repo))
+        repo.git.push("--set-upstream", "origin", "main")
+        (repo_path / "later.txt").write_text("later\n")
+        stage_all(repo_path)
+        commit_changes(repo_path, "later work")
+
+        # Act
+        info = get_repo_info(repo_path)
+
+        # Assert
+        assert info.ahead == 1
+
+    def test_ahead_returns_to_zero_after_push(self, repo_path, remote_repo):
+        # Arrange
+        repo = Repo(repo_path)
+        repo.create_remote("origin", str(remote_repo))
+        repo.git.push("--set-upstream", "origin", "main")
+        (repo_path / "later.txt").write_text("later\n")
+        stage_all(repo_path)
+        commit_changes(repo_path, "later work")
+
+        # Act
+        git_push(repo_path)
+
+        # Assert
+        assert get_repo_info(repo_path).ahead == 0
+
+
+class TestIsDirty:
+    def test_clean_repo_is_not_dirty(self, repo_path):
+        # Act
+        dirty, _summary = is_dirty(repo_path)
+
+        # Assert
+        assert dirty is False
+
+    def test_modified_file_makes_repo_dirty(self, repo_path):
+        # Arrange
+        (repo_path / "README.md").write_text("# changed\n")
+
+        # Act
+        dirty, summary = is_dirty(repo_path)
+
+        # Assert
+        assert dirty is True
+        assert summary
+
+    def test_untracked_file_makes_repo_dirty(self, repo_path):
+        # Arrange
+        (repo_path / "stray.txt").write_text("stray\n")
+
+        # Act
+        dirty, _summary = is_dirty(repo_path)
+
+        # Assert
+        assert dirty is True
+
+
+class TestGetRepoInfo:
+    def test_reports_branch_and_clean_status(self, repo_path):
+        # Act
+        info = get_repo_info(repo_path)
+
+        # Assert
+        assert info.branch == "main"
+        assert info.status == RepoStatus.CLEAN
+        assert info.total_commits == 1
+
+    def test_untracked_file_is_counted(self, repo_path):
+        # Arrange
+        (repo_path / "stray.txt").write_text("stray\n")
+
+        # Act
+        info = get_repo_info(repo_path)
+
+        # Assert
+        assert info.status == RepoStatus.UNTRACKED
+        assert info.modified_count >= 1
+
+    def test_last_commit_message_is_populated(self, repo_path):
+        # Act
+        info = get_repo_info(repo_path)
+
+        # Assert
+        assert info.last_commit_msg == "initial commit"
+        assert info.last_commit_ts > 0
+
+    def test_non_repo_directory_yields_placeholder(self, tmp_path):
+        # Arrange — a directory that is not a git repo
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        # Act
+        info = get_repo_info(plain)
+
+        # Assert — get_repo_info swallows the error and degrades
+        assert info.branch == "unknown"
+        assert info.last_commit_ts == 0.0

--- a/tests/test_ui_behaviour.py
+++ b/tests/test_ui_behaviour.py
@@ -1,0 +1,283 @@
+"""
+Behavioural coverage for the TUI, driven through Textual's test pilot.
+
+These exercise the interaction defects fixed alongside them, so a regression
+shows up as a failing test rather than a bug report.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Input, ListView
+
+from gitpulse.main import GitPulseApp
+from gitpulse.ui.error_log import ErrorLogScreen
+from gitpulse.ui.sidebar import RepoSidebar, _fit, column_widths
+
+async def _booted(fleet, size=(140, 40)):
+    """Yield an app with its initial scan complete."""
+    app = GitPulseApp(root_dir=fleet, commits=5, watch=False)
+    return app
+
+
+async def _await_scan(app, pilot) -> None:
+    """Block until the initial scan has populated the sidebar."""
+    for _ in range(50):
+        if app._all_repos and app._selected_repo is not None:
+            break
+        await pilot.pause(0.1)
+    assert app._all_repos, "scan did not complete"
+    # Let the sidebar finish populating before anything touches the list.
+    await pilot.pause()
+
+
+async def _highlight(app, pilot, name: str):
+    """Move the sidebar highlight to the repo called *name* and settle.
+
+    Setting ``ListView.index`` posts a Highlighted message, so the selection
+    lands only once the message pump has run; poll until it does rather than
+    guessing at a fixed number of pauses.
+    """
+    lv = app.query_one("#repo-list", ListView)
+    index = next(i for i, r in enumerate(app.repos) if r.name == name)
+    lv.index = index
+    for _ in range(20):
+        if app._selected_repo is not None and app._selected_repo.name == name:
+            break
+        await pilot.pause(0.05)
+    assert app._selected_repo.name == name, (
+        f"highlight did not land on {name!r}; got {app._selected_repo.name!r}"
+    )
+    return app.repos[index]
+
+
+class TestFilterPreservesSelection:
+    async def test_filter_keeps_the_selected_repo(self, fleet):
+        """Narrowing the filter must not yank the user off their repo."""
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange — select a specific repo by name
+            await _await_scan(app, pilot)
+            target = await _highlight(app, pilot, "dirty")
+
+            # Act — filter by a substring the selected repo still matches
+            app._apply_filter("dir")
+            await pilot.pause()
+
+            # Assert
+            assert app._selected_repo.path == target.path
+
+    async def test_selection_moves_when_filtered_out(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            await _highlight(app, pilot, "dirty")
+
+            # Act — a filter that excludes the current selection
+            app._apply_filter("committed")
+            await pilot.pause()
+
+            # Assert
+            assert app._selected_repo.name == "committed"
+
+    async def test_typing_in_search_does_not_reset_each_keystroke(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            selected = await _highlight(app, pilot, "committed")
+            app.query_one("#search-input", Input).focus()
+            await pilot.pause()
+
+            # Act — type a prefix the selection still matches
+            for ch in "com":
+                await pilot.press(ch)
+                await pilot.pause()
+
+            # Assert
+            assert app._selected_repo.path == selected.path
+
+
+class TestVimNavigation:
+    async def test_j_and_k_move_the_highlight(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            lv = app.query_one("#repo-list", ListView)
+            lv.index = 0
+            await pilot.pause()
+
+            # Act
+            await pilot.press("j")
+            await pilot.pause()
+            after_down = lv.index
+            await pilot.press("k")
+            await pilot.pause()
+
+            # Assert
+            assert after_down == 1
+            assert lv.index == 0
+
+    async def test_j_clamps_at_the_last_row(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            lv = app.query_one("#repo-list", ListView)
+
+            # Act — press well past the end
+            for _ in range(10):
+                await pilot.press("j")
+            await pilot.pause()
+
+            # Assert
+            assert lv.index == len(app.repos) - 1
+
+    async def test_j_types_into_the_search_box_when_focused(self, fleet):
+        """Vim keys must not steal keystrokes from the filter input."""
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            search = app.query_one("#search-input", Input)
+            search.focus()
+            await pilot.pause()
+
+            # Act
+            await pilot.press("j")
+            await pilot.pause()
+
+            # Assert
+            assert search.value == "j"
+
+
+class TestErrorLog:
+    async def test_e_opens_the_error_log(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            app._record_error("something broke")
+
+            # Act
+            await pilot.press("e")
+            await pilot.pause()
+
+            # Assert
+            assert isinstance(app.screen, ErrorLogScreen)
+
+    async def test_escape_closes_the_error_log(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            await pilot.press("e")
+            await pilot.pause()
+
+            # Act
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Assert
+            assert not isinstance(app.screen, ErrorLogScreen)
+
+    async def test_opens_cleanly_with_no_errors_recorded(self, fleet):
+        app = await _booted(fleet)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+
+            # Act
+            await pilot.press("e")
+            await pilot.pause()
+
+            # Assert
+            assert isinstance(app.screen, ErrorLogScreen)
+
+
+class TestErrorRingBuffer:
+    def test_records_details(self):
+        app = GitPulseApp(root_dir=".", watch=False)
+        app._record_error("boom")
+        assert app._error_log == ["boom"]
+
+    def test_ignores_empty_details(self):
+        app = GitPulseApp(root_dir=".", watch=False)
+        app._record_error("")
+        assert app._error_log == []
+
+    def test_caps_at_fifty_entries(self):
+        app = GitPulseApp(root_dir=".", watch=False)
+        for i in range(60):
+            app._record_error(f"error {i}")
+        assert len(app._error_log) == 50
+        assert app._error_log[-1] == "error 59"
+
+
+class TestSidebarLayout:
+    def test_columns_fill_the_available_width(self):
+        from gitpulse.ui.sidebar import _ROW_CHROME
+
+        for avail in (34, 44, 54, 80):
+            w_repo, w_branch = column_widths(avail)
+            assert w_repo + w_branch + _ROW_CHROME == avail
+
+    def test_columns_grow_with_available_width(self):
+        narrow_repo, _ = column_widths(38)
+        wide_repo, _ = column_widths(80)
+        assert wide_repo > narrow_repo
+
+    def test_columns_have_floors_on_tiny_widths(self):
+        w_repo, w_branch = column_widths(10)
+        assert w_repo >= 10
+        assert w_branch >= 8
+
+    def test_fit_pads_short_values(self):
+        assert _fit("ab", 5) == "ab   "
+
+    def test_fit_truncates_with_ellipsis(self):
+        assert _fit("abcdef", 4) == "abc…"
+
+    def test_fit_handles_degenerate_widths(self):
+        assert _fit("abc", 0) == ""
+        assert _fit("abc", 1) == "…"
+
+
+class TestFleetStrip:
+    async def test_all_chips_are_visible_on_a_narrow_terminal(self, fleet):
+        """Every counter must render — a clipped chip hides fleet state."""
+        from gitpulse.ui.fleet_status import FleetChip, FleetStatus
+
+        app = GitPulseApp(root_dir=fleet, commits=5, watch=False)
+        async with app.run_test(size=(95, 34)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+            strip = app.query_one("#fleet-status", FleetStatus)
+            chips = list(strip.query(FleetChip))
+
+            # Act — total width the chips need, including their margins
+            needed = sum(len(str(c.render())) + 1 for c in chips)
+
+            # Assert — the six chips fit the strip's content area
+            assert len(chips) == 6
+            assert needed <= strip.container_size.width + 1, (
+                f"chips need {needed} cols but only "
+                f"{strip.container_size.width} are available"
+            )
+
+    async def test_counters_reflect_the_fleet(self, fleet):
+        from gitpulse.ui.fleet_status import FleetChip, FleetStatus
+
+        app = GitPulseApp(root_dir=fleet, commits=5, watch=False)
+        async with app.run_test(size=(140, 40)) as pilot:
+            # Arrange
+            await _await_scan(app, pilot)
+
+            # Act
+            strip = app.query_one("#fleet-status", FleetStatus)
+            dirty_chip = strip.query_one("#chip-dirty", FleetChip)
+
+            # Assert — the fixture has exactly one repo with changes
+            assert "1" in str(dirty_chip.render())


### PR DESCRIPTION
Closes #26, closes #27, closes #28, closes #29, closes #30, closes #31, closes #32, closes #33, closes #34, closes #35, closes #36, closes #37.

Tracked by #23, #24, #25.

## What changed

Three strands of work in one branch. Tests go from **107 → 185**, all passing.

### UI/UX correctness

| Issue | Fix |
|---|---|
| #26 | Filtering no longer yanks the selection away on every keystroke |
| #27 | Scan fans `get_repo_info` over a thread pool instead of running it serially |
| #28 | The error ring buffer is now readable — `ErrorLogScreen`, bound to `e` |
| #34 | Every binding carries a stable `id`; added vim `j`/`k` |
| #35 | Sidebar column widths derive from actual width instead of a hardcoded 16/15 |

Two additional defects surfaced while verifying the above and are fixed here:

- **Stale `Highlighted` events.** `populate()` clears and refills the `ListView`, and those mutations queue `Highlighted` events delivered *after* it returns, carrying rows from the *previous* list. The late event clobbered the selection `populate()` had just restored. Without this, the #26 fix would have been intermittently wrong. `on_list_view_highlighted` now drops events whose item is no longer in the current list.
- **Fleet strip clipping.** `FleetStatus` subclassed `Widget`, so `layout: horizontal` never applied to its children — six chips needed 42 columns against a ~31-column sidebar and were silently cut off. Now subclasses `Horizontal`, with abbreviated labels and tooltips carrying the full meaning.
- **Contradictory empty state.** The Status card read "Untracked / 1 untracked" while the pane below said "Working tree is clean", because `_empty_row` hardcoded that subtitle for every list.

### Agent mode

```bash
gitpulse scan --json            # full fleet state, one JSON document
gitpulse scan --json --ahead    # only repos with unpushed commits
gitpulse scan --ndjson          # one object per line
gitpulse context                # Markdown pack for an LLM prompt
```

```python
from gitpulse.api import scan_fleet
unpushed = [r for r in scan_fleet("~/Projects") if r.ahead > 0]
```

`gitpulse.api` is read-only and **guaranteed never to import Textual** — enforced by a subprocess test, not a convention. It defines the JSON schema in one place so the CLI, the context pack, and any future MCP server cannot drift.

One correctness point worth calling out: `get_repo_info` catches its own errors and returns a placeholder with `branch="unknown"`, which is indistinguishable from a genuinely clean repo. Serialised naively, an unreadable directory would have told an agent there was nothing to do. Those are now emitted as `"status": "unreadable"` with `"readable": false`, and listed separately in the context pack under an explicit "unknown, not clean" note.

The dual-import blocks are gone from all 12 modules. The `except ImportError` fallback mutated `sys.path` at import time, which is what made importing GitPulse into another process unsafe — the actual blocker for the library API. Argument parsing moved out of `main.py` into `cli.py`, so Textual is imported lazily and only when the TUI is launched.

### Packaging and release safety

- `pyproject.toml` gained `license`, `readme`, `classifiers`, `keywords`, `authors`, and `[project.urls]` — PyPI previously showed none of what `npm/package.json` already declared. README image paths absolutised so they render there rather than 404ing.
- Upper bounds on `textual`/`rich`/`gitpython`, plus a weekly canary job that installs the latest releases so the ceilings can't go stale silently.
- `publish.yml` now depends on a test job across Python 3.10–3.13. The 3.10 entry matters: `config.py` branches between the `tomli` backport and stdlib `tomllib`, and CI only ever ran 3.12.
- New `ci.yml` for pull requests, since PRs previously got no automated feedback at all.

## Verification

- `pytest -q` → **185 passed**; the three timing-sensitive UI tests confirmed stable across repeated runs
- `python -m build && twine check dist/*` → PASSED, with license/URLs/classifiers/README body confirmed present in the wheel metadata
- Clean install from the sdist into a fresh venv, then `gitpulse --version` and `gitpulse scan --json`
- TUI driven through Textual's pilot and screenshotted at **95** and **150** columns to confirm the layout fixes actually render

New test files: `test_git_ops_writes.py` (24 — every destructive path, `git_push` against a local bare repo, no network), `test_api.py` (13), `test_cli.py` (13, real subprocesses), `test_context.py` (8), `test_ui_behaviour.py` (20).

## Breaking change

`python gitpulse/main.py` no longer works — use `python -m gitpulse`. This is the direct-execution path the removed `sys.path` fallback existed to support. The `gitpulse` console script and the npm launcher both use the entry point and are unaffected.

## Deliberately out of scope

An MCP server. It should be built *on* `gitpulse.api` rather than shelling out, so it's worth landing this first and letting the schema settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
