### PR TITLE
feat: agent skill, AGENTS.md, and a genuinely useful --help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# GitPulse for coding agents
+
+GitPulse reports the state of **every local git repository under a directory**
+in one call. `git status` answers for one repo; this answers for all of them, as
+JSON.
+
+Applies to any agent that reads this file (Claude Code, Cursor, Codex, Aider,
+and others). Claude Code users can instead install the richer skill in
+[`skills/gitpulse/`](./skills/gitpulse/SKILL.md).
+
+## Install
+
+```bash
+pip install gitpulse-tui        # or: pipx install gitpulse-tui
+gitpulse --version              # verify before relying on it
+```
+
+## The command
+
+```bash
+gitpulse scan --root ~/Projects --json --indent 0
+```
+
+Only JSON goes to stdout — safe to pipe straight into a parser. Use
+`--indent 0` when parsing; drop it when a human will read the output.
+
+Narrow at the source rather than fetching everything and filtering:
+
+```bash
+gitpulse scan --json --dirty     # uncommitted changes only
+gitpulse scan --json --ahead     # unpushed commits only
+gitpulse scan --ndjson           # one object per line
+```
+
+## Output
+
+```json
+{
+  "schema_version": 1,
+  "scanned_at": "2026-08-07T15:49:41+00:00",
+  "root": "/home/you/Projects",
+  "repo_count": 12,
+  "repos": [
+    {
+      "name": "gitpulse",
+      "path": "/home/you/Projects/gitpulse",
+      "branch": "main",
+      "status": "clean",
+      "readable": true,
+      "modified_count": 0,
+      "ahead": 0,
+      "behind": 0,
+      "stash_count": 0,
+      "has_stale_branches": false,
+      "last_commit": { "ts": 1754553600, "iso": "…", "message": "…" },
+      "total_commits": 142,
+      "contributor_count": 3,
+      "commit_activity": [0, 1, 4, 2, 0, 7, 3]
+    }
+  ],
+  "errors": []
+}
+```
+
+`status` ∈ `clean` | `modified` | `untracked` | `unreadable`.
+Repos are sorted most-recently-committed first.
+`commit_activity` is commits per week for 7 weeks, oldest first.
+
+## Rules for reading it
+
+**`"readable": false` means unknown, not clean.** Such a repo could not be
+inspected. Never report it as having nothing to do — name it and say its state
+is undetermined.
+
+**Check `errors[]` before summarising.** A non-empty array means the picture is
+incomplete.
+
+**`ahead: 0` does not prove a branch is pushed.** It is also `0` when the branch
+has no upstream at all. Say so rather than implying everything is synced.
+
+**Exit code 0 does not mean the fleet is clean.** It means the scan succeeded.
+Read the data. Exit `1` means the scan itself failed (bad root, bad `--since`).
+
+## Field reference
+
+| Question | Field |
+|---|---|
+| Uncommitted work? | `status != "clean"` or `modified_count > 0` |
+| Unpushed commits? | `ahead > 0` |
+| Needs a pull? | `behind > 0` |
+| Diverged? | `ahead > 0 && behind > 0` |
+| Forgotten WIP? | `stash_count > 0` |
+| Branch cleanup available? | `has_stale_branches` |
+
+## Prose instead of data
+
+```bash
+gitpulse context                  # Markdown, action-ordered, for a prompt
+gitpulse context --max-repos 15   # cap it on a large fleet
+gitpulse digest --since 7d        # "what did I commit this week"
+```
+
+Use `context` when you will summarise for a human anyway — cheaper than
+fetching JSON and rewriting it. Use `digest` for activity over a window;
+`--since` takes `1d`, `7d`, `2w`, `4h`, `yesterday`, `today`, or `YYYY-MM-DD`.
+
+## In-process (Python)
+
+```python
+from gitpulse.api import scan_fleet, scan_fleet_detailed, repo_state
+
+unpushed = [r for r in scan_fleet("~/Projects") if r.ahead > 0]
+result = scan_fleet_detailed("~/Projects")   # also carries .errors
+one = repo_state("~/Projects/gitpulse")
+```
+
+`gitpulse.api` is read-only and never imports Textual, so it is cheap to import
+into a non-TUI process.
+
+## Choosing a root
+
+`--root` is optional; without it GitPulse uses `scan.roots` from
+`~/.config/gitpulse/config.toml`, then the current directory. Scanning `~`
+directly is slow and noisy — ask which directory the user means rather than
+guessing.
+
+## Cost and scope
+
+Each repo costs roughly seven git subprocesses, run in parallel. Scan once and
+reuse the result within a task instead of re-running per question. Tune with
+`--max-workers N`.
+
+Everything documented here is **read-only**. GitPulse's mutating operations
+(commit, push, branch delete, bulk fetch) are intentionally not part of this
+contract — use `git` directly so writes stay explicit and scoped.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ from gitpulse.api import scan_fleet
 unpushed = [r for r in scan_fleet("~/Projects") if r.ahead > 0]
 ```
 
+### Teaching your agent to use it
+
+**Claude Code** — install the bundled skill, and Claude will reach for GitPulse
+on its own whenever you ask about "my repos", "what haven't I pushed", or want
+a standup summary:
+
+```bash
+git clone https://github.com/lebiraja/gitpulse.git
+mkdir -p ~/.claude/skills
+cp -r gitpulse/skills/gitpulse ~/.claude/skills/gitpulse
+```
+
+Then just ask: *"which of my projects have uncommitted work?"*
+
+**Any other agent** (Cursor, Codex, Aider, …) — [`AGENTS.md`](./AGENTS.md) is a
+vendor-neutral description of the same CLI contract. Drop it in your project
+root, or paste it into your agent's rules/system prompt.
+
+Both documents cover the same ground: the JSON schema, how to narrow with
+`--dirty` / `--ahead`, and the failure modes worth knowing — chiefly that
+`"readable": false` means *unknown*, not clean, and that `ahead: 0` does not
+prove a branch is pushed when it has no upstream.
+
 ## Features
 
 - **Multi-repo dashboard** — Scans a directory tree and lists every local Git repo, sorted by most recent activity

--- a/gitpulse/cli.py
+++ b/gitpulse/cli.py
@@ -23,13 +23,104 @@ from pathlib import Path
 from . import config as _config
 from .utils import __version__
 
-_TIME_SPEC_HELP = "1d, 7d, 30d, yesterday, today, or YYYY-MM-DD"
+_TIME_SPEC_HELP = "1d, 7d, 2w, 4h, yesterday, today, or YYYY-MM-DD"
+
+_MAIN_EPILOG = """\
+examples:
+  gitpulse                            launch the dashboard for the configured root
+  gitpulse --root ~/Projects          launch the dashboard for a specific directory
+
+  gitpulse scan --json                fleet state as JSON (for scripts and agents)
+  gitpulse scan --json --ahead        only repos with unpushed commits
+  gitpulse context                    fleet state as Markdown, for an LLM prompt
+  gitpulse digest --since 7d          what you committed in the last week
+
+dashboard keys:
+  /  filter repos          j / k or arrows  move            [ ]  switch tab
+  r  rescan                Space / *        select / all    :    bulk actions
+  w  toggle watch mode     d  digest        b  stale branches
+  e  error log             ?  help          q  quit
+
+configuration:
+  ~/.config/gitpulse/config.toml  — scan roots, excluded dirs, author emails,
+  watch interval, stale threshold, worker count. CLI flags always win.
+  An annotated example is written to config.toml.example on first run.
+
+Full documentation: https://github.com/lebiraja/gitpulse
+"""
+
+_SCAN_EPILOG = """\
+examples:
+  gitpulse scan --json                       every repo, indented JSON
+  gitpulse scan --json --indent 0            compact — fewer tokens for an agent
+  gitpulse scan --json --dirty               only repos with uncommitted changes
+  gitpulse scan --json --ahead               only repos with unpushed commits
+  gitpulse scan --ndjson                     one JSON object per line
+  gitpulse scan --root ~/work --json | jq '.repos[] | select(.behind > 0) | .name'
+
+output:
+  A JSON envelope with schema_version, scanned_at (ISO-8601 UTC), root,
+  repo_count, repos[], and errors[]. Each repo carries name, path, branch,
+  status, readable, modified_count, ahead, behind, stash_count,
+  has_stale_branches, last_commit{ts,iso,message}, total_commits,
+  contributor_count, and commit_activity[] (commits per week, 7 weeks).
+
+  status is one of: clean, modified, untracked, unreadable.
+
+  A repo with "readable": false could not be inspected — its state is unknown,
+  NOT clean. Check the errors[] array too; if it is non-empty the picture is
+  incomplete.
+
+  Only JSON goes to stdout, so it is safe to pipe directly into a parser.
+  Exit status is 0 even when repos are dirty; 1 means the scan itself failed.
+"""
+
+_CONTEXT_EPILOG = """\
+examples:
+  gitpulse context                     full fleet summary
+  gitpulse context --max-repos 15      cap each section on a large fleet
+  gitpulse context > /tmp/fleet.md     save it to paste into a prompt
+
+output:
+  Markdown ordered by what needs action: repos needing attention first, an
+  unpushed-work table, stale branches, then clean repos collapsed to a single
+  name list. Repos that could not be read are listed separately and explicitly
+  marked as unknown rather than clean.
+
+  Use this when a human will read the summary. Use `scan --json` when a program
+  will parse it.
+"""
+
+_DIGEST_EPILOG = """\
+examples:
+  gitpulse digest --since 7d                     your commits this week
+  gitpulse digest --since yesterday              since yesterday midnight
+  gitpulse digest --since 2026-01-01             since a specific date
+  gitpulse digest --author you@example.com       filter to one author
+  gitpulse digest --author a@x.com --author b@x.com   several authors
+
+output:
+  Markdown grouped by repository, with per-commit insertion/deletion counts and
+  a fleet-wide total. Answers "what did I do", where `context` answers "what is
+  the state right now".
+
+  With no --author, the digest uses author.emails from config.toml, falling back
+  to each repository's own git config user.email.
+"""
 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gitpulse",
-        description="GitPulse — Git repo fleet dashboard. Run without arguments for the TUI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "GitPulse — a dashboard for every git repository on your machine.\n\n"
+            "Scans a directory tree for local git repos and shows which have "
+            "uncommitted\nchanges, unpushed commits, stashes, or stale branches. "
+            "Run with no arguments\nfor the interactive dashboard, or use a "
+            "subcommand for scriptable output."
+        ),
+        epilog=_MAIN_EPILOG,
     )
     parser.add_argument(
         "--version", action="version", version=f"gitpulse {__version__}"
@@ -60,24 +151,41 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # Bare `gitpulse` accepts the common options plus the TUI-only ones.
     add_common(parser)
-    parser.add_argument(
-        "--commits", type=int, default=10, metavar="N",
-        help="Commits to display per repo in the TUI (default: 10)",
+    tui_group = parser.add_argument_group(
+        "dashboard options", "Only apply when launching the interactive TUI"
     )
-    parser.add_argument(
+    tui_group.add_argument(
+        "--commits", type=int, default=10, metavar="N",
+        help="Commits to show per repo in the Commits tab (default: 10)",
+    )
+    tui_group.add_argument(
         "--no-watch", action="store_true", default=False,
-        help="Disable live watch mode",
+        help="Disable live auto-refresh when repos change on disk",
     )
 
     common = argparse.ArgumentParser(add_help=False)
     add_common(common)
 
-    sub = parser.add_subparsers(dest="command")
+    sub = parser.add_subparsers(
+        dest="command",
+        title="subcommands",
+        metavar="{scan,context,digest}",
+        description=(
+            "Non-interactive output for scripts, pipelines, and coding agents.\n"
+            "Run `gitpulse <subcommand> --help` for details and examples."
+        ),
+    )
 
     p_scan = sub.add_parser(
         "scan", parents=[common],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         help="Print fleet state as JSON and exit",
-        description="Scan the fleet and emit machine-readable state on stdout.",
+        description=(
+            "Scan the fleet and emit machine-readable state on stdout.\n\n"
+            "This is the command for scripts and coding agents: it answers\n"
+            "\"which of my repos have unpushed work?\" in a single call."
+        ),
+        epilog=_SCAN_EPILOG,
     )
     fmt = p_scan.add_mutually_exclusive_group()
     fmt.add_argument(
@@ -103,8 +211,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_ctx = sub.add_parser(
         "context", parents=[common],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         help="Print fleet state as a Markdown context pack",
-        description="Render fleet state as Markdown sized for an LLM context window.",
+        description=(
+            "Render fleet state as Markdown sized for an LLM context window.\n\n"
+            "State-first and ordered by what needs action, so it stays useful\n"
+            "when pasted straight into a prompt or a standup note."
+        ),
+        epilog=_CONTEXT_EPILOG,
     )
     p_ctx.add_argument(
         "--max-repos", type=int, default=40, metavar="N",
@@ -113,8 +227,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_dig = sub.add_parser(
         "digest", parents=[common],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         help="Print an author activity digest as Markdown",
-        description="Summarise recent commit activity by author across the fleet.",
+        description=(
+            "Summarise recent commit activity by author across the fleet.\n\n"
+            "Answers \"what did I do\"; use `context` for \"what is the state now\"."
+        ),
+        epilog=_DIGEST_EPILOG,
     )
     p_dig.add_argument(
         "--since", type=str, default=None, metavar="SPEC",

--- a/skills/gitpulse/SKILL.md
+++ b/skills/gitpulse/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: gitpulse
+description: Inspect the state of every local git repository under a directory in one call — which repos have uncommitted changes, unpushed commits, stashes, or stale branches. Use when the user asks about "my repos", "all my projects", "what have I not pushed", "what am I working on", "anything uncommitted", "which repos need attention", before a standup or end-of-day wrap-up, when writing a status update spanning several repos, or when a task requires knowing the state of more than one repository at once. Requires the `gitpulse` CLI (pip install gitpulse-tui).
+---
+
+# GitPulse — fleet-wide git state
+
+`git status` answers for one repo. GitPulse answers for all of them at once, as
+JSON, in a single call.
+
+## Check availability first
+
+```bash
+gitpulse --version
+```
+
+If this fails, GitPulse is not installed. Tell the user:
+`pip install gitpulse-tui` (or `pipx install gitpulse-tui`). Do not attempt to
+install it yourself unless asked.
+
+## The one command that matters
+
+```bash
+gitpulse scan --root ~/Projects --json
+```
+
+Emits a single JSON document on stdout and nothing else — safe to pipe straight
+into a parser.
+
+### Narrowing
+
+```bash
+gitpulse scan --root ~/Projects --json --dirty    # uncommitted changes only
+gitpulse scan --root ~/Projects --json --ahead    # unpushed commits only
+gitpulse scan --root ~/Projects --ndjson          # one object per line
+gitpulse scan --root ~/Projects --json --indent 0 # compact, fewer tokens
+```
+
+Prefer `--dirty` / `--ahead` over scanning everything and filtering yourself —
+it is the same cost to run and far fewer tokens to read back.
+
+Use `--indent 0` whenever you are only going to parse the output. Reserve
+indented JSON for when the user will read it directly.
+
+## Response shape
+
+```json
+{
+  "schema_version": 1,
+  "scanned_at": "2026-08-07T15:49:41+00:00",
+  "root": "/home/lebi/Projects",
+  "repo_count": 12,
+  "repos": [
+    {
+      "name": "gitpulse",
+      "path": "/home/lebi/Projects/gitpulse",
+      "branch": "main",
+      "status": "clean",
+      "readable": true,
+      "modified_count": 0,
+      "ahead": 0,
+      "behind": 0,
+      "stash_count": 0,
+      "has_stale_branches": false,
+      "last_commit": {
+        "ts": 1754553600,
+        "iso": "2026-08-07T08:00:00+00:00",
+        "message": "chore: bump version to 1.2.15"
+      },
+      "total_commits": 142,
+      "contributor_count": 3
+    }
+  ],
+  "errors": []
+}
+```
+
+`status` is one of `clean`, `modified`, `untracked`, `unreadable`.
+
+`commit_activity` (omitted above) is commits per week for the last 7 weeks,
+oldest first.
+
+### Read `readable` before you conclude anything
+
+**A repo with `"readable": false` has `"status": "unreadable"` — its state is
+unknown, not clean.** Never report such a repo as having nothing to do. Say its
+state could not be determined, and name it.
+
+Repos that could not be opened at all appear in the top-level `errors` array as
+`{"path": ..., "error": ...}`. Check it before summarising; a non-empty
+`errors` array means the picture is incomplete.
+
+## Interpreting the fields
+
+| Question | Field |
+|---|---|
+| Uncommitted work? | `status != "clean"`, or `modified_count > 0` |
+| Unpushed commits? | `ahead > 0` |
+| Needs a pull? | `behind > 0` |
+| Both, i.e. diverged? | `ahead > 0 && behind > 0` |
+| Forgotten work in progress? | `stash_count > 0` |
+| Branch cleanup available? | `has_stale_branches` |
+| Recently active? | `last_commit.ts`, sorted descending by default |
+
+Repos come back sorted most-recently-committed first.
+
+`ahead`/`behind` are `0` when a branch has no upstream — that is not the same as
+being in sync. If it matters, say so rather than implying the repo is pushed.
+
+## When the user wants prose, not data
+
+```bash
+gitpulse context --root ~/Projects
+```
+
+Markdown built for a context window: repos needing attention first, an unpushed
+work table, stale branches, and clean repos collapsed to a single name list.
+Use this when you are about to summarise the fleet for a human anyway — it is
+cheaper than fetching JSON and rewriting it. Cap it with `--max-repos N` on a
+large fleet.
+
+For "what did I do this week", use the author digest instead:
+
+```bash
+gitpulse digest --since 7d
+gitpulse digest --since 7d --author you@example.com
+```
+
+`--since` accepts `1d`, `7d`, `2w`, `4h`, `yesterday`, `today`, or `YYYY-MM-DD`.
+
+## Python API
+
+When already in Python, skip the subprocess. `gitpulse.api` is read-only and
+never imports Textual:
+
+```python
+from gitpulse.api import scan_fleet, scan_fleet_detailed, repo_state
+
+unpushed = [r for r in scan_fleet("~/Projects") if r.ahead > 0]
+
+result = scan_fleet_detailed("~/Projects")   # carries .errors too
+one = repo_state("~/Projects/gitpulse")
+```
+
+## Choosing a root
+
+`--root` is optional. Without it GitPulse uses the first entry in
+`scan.roots` from `~/.config/gitpulse/config.toml`, then falls back to the
+current directory. Pass `--root` explicitly when the user names a directory;
+omit it to respect their configured default.
+
+Scanning `~` directly is slow and noisy. Ask which directory they mean rather
+than guessing, unless a config default exists.
+
+## Cost
+
+Each repo costs roughly seven git subprocesses, run in parallel. A few dozen
+repos is fast; several hundred is not. Scan once and reuse the result within a
+task rather than re-running per question. Tune with `--max-workers N`.
+
+## Scope
+
+Every command here is **read-only**. GitPulse's mutating operations (commit,
+push, branch delete, bulk fetch) are deliberately not exposed to this skill —
+use `git` directly for those, so the write stays visible and scoped to one repo.
+
+Exit codes: `0` success, `1` bad root or bad `--since` spec. A dirty fleet is
+still exit `0` — check the data, not the exit code.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,3 +146,57 @@ class TestTopLevel:
         # Assert
         for name in ("scan", "context", "digest"):
             assert name in result.stdout
+
+
+class TestHelpText:
+    def test_main_help_shows_examples_and_keys(self):
+        # Act
+        result = run_cli("--help")
+
+        # Assert
+        assert "examples:" in result.stdout
+        assert "dashboard keys:" in result.stdout
+        assert "configuration:" in result.stdout
+
+    def test_main_help_separates_tui_only_options(self):
+        """--commits/--no-watch do nothing for the subcommands; say so."""
+        # Act
+        result = run_cli("--help")
+
+        # Assert
+        assert "dashboard options:" in result.stdout
+
+    def test_scan_help_documents_the_schema(self):
+        # Act
+        result = run_cli("scan", "--help")
+
+        # Assert
+        for field in ("schema_version", "repo_count", "errors[]", "unreadable"):
+            assert field in result.stdout
+
+    def test_scan_help_warns_that_unreadable_is_not_clean(self):
+        """The most dangerous misreading of the output deserves a warning."""
+        # Act
+        result = run_cli("scan", "--help")
+
+        # Assert
+        assert "NOT clean" in result.stdout
+
+    def test_every_subcommand_help_carries_examples(self):
+        for cmd in ("scan", "context", "digest"):
+            # Act
+            result = run_cli(cmd, "--help")
+
+            # Assert
+            assert "examples:" in result.stdout, f"{cmd} help has no examples"
+
+    def test_digest_help_lists_supported_time_specs(self):
+        # Act
+        result = run_cli("digest", "--help")
+
+        # Assert — every spec advertised must actually parse
+        from gitpulse.utils import parse_since
+
+        for spec in ("1d", "7d", "2w", "4h", "yesterday", "today"):
+            assert spec in result.stdout
+            parse_since(spec)


### PR DESCRIPTION
Follow-on to #38. Ships the agent-facing surface *discoverably* — the JSON API was only half the job, since an agent still had to be told it exists.

## Claude Code skill — `skills/gitpulse/SKILL.md`

Installed by copying into `~/.claude/skills/`. Triggers on the phrasings people actually use: *"my repos"*, *"what haven't I pushed"*, *"anything uncommitted"*, standup and end-of-day wrap-up.

It leads with the failure modes rather than the happy path, because those are what produce wrong answers:

- **`"readable": false` means unknown, NOT clean** — an agent reporting such a repo as fine is the single worst misread of this output
- **`errors[]` must be checked** before summarising, or the picture is silently incomplete
- **`ahead: 0` does not prove a branch is pushed** — it is also `0` when there is no upstream at all
- **Exit `0` does not mean the fleet is clean**, it means the scan succeeded

Deliberately **read-only**. The mutating `git_ops` (commit, push, branch delete, bulk fetch) are not exposed, so writes stay explicit and scoped to one repo via `git` itself.

## `AGENTS.md`

Same contract, vendor-neutral, for Cursor / Codex / Aider and anything else that reads the convention.

## `--help` rewrite

This was raised separately and is the larger diff. The old help was a bare flag dump that **never mentioned the JSON surface at all** — the entire agent-facing feature set was invisible to anyone running `gitpulse --help`.

Before:

```
usage: gitpulse [-h] [--version] [--root ROOT] ... {scan,context,digest} ...

GitPulse — Git repo fleet dashboard. Run without arguments for the TUI.
```

Now:

- **Main help** carries examples, the dashboard keybindings, and the config file location
- **`--commits` / `--no-watch` moved into a "dashboard options" group** — they do nothing for the subcommands, which the flat list implied otherwise
- **Every subcommand gained `examples:` and an `output:` section.** `scan --help` documents the full JSON envelope field by field and repeats the "NOT clean" warning
- **Added `2w` / `4h`** to the advertised `--since` specs — they always worked, they were just undocumented

One correctness check while writing it: the help claims an annotated `config.toml.example` is written on first run. Verified that against `config.py:99` rather than asserting it from memory.

## Tests

185 → **191**. The new ones assert help *content*, not just exit status — including that every `--since` spec named in the help actually parses, so the examples cannot rot as flags change.

## Verification

Installed the skill locally, invoked it, and let it drive against a real 12-repo fleet. It correctly identified 3 repos with uncommitted work and 9 clean, with `errors: 0`. Also confirmed both flagged repos had real upstreams, so the `ahead: 0` caveat was not silently masking anything in that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
