### PR TITLE
feat: gitpulse --update self-upgrade with install-method detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ pip install gitpulse-tui        # or: pipx install gitpulse-tui
 gitpulse --version              # verify before relying on it
 ```
 
+If a flag or field documented here is missing, the installed copy is old.
+`gitpulse --check-update` reports whether a newer release exists and installs
+nothing. Do **not** run `gitpulse --update` unless the user asks for it — it
+modifies their environment.
+
 ## The command
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ gitpulse --no-watch                # disable live watch mode
 gitpulse --config path/to.toml     # use a custom config file
 gitpulse --version                 # print version
 
+gitpulse --update                  # upgrade to the latest release
+gitpulse --check-update            # report if one exists, install nothing
+
 # Activity digest (prints markdown, no TUI):
 gitpulse digest --since 7d                 # last 7 days
 gitpulse digest --since 2024-01-01         # since a date
@@ -139,6 +142,31 @@ Both documents cover the same ground: the JSON schema, how to narrow with
 `--dirty` / `--ahead`, and the failure modes worth knowing — chiefly that
 `"readable": false` means *unknown*, not clean, and that `ahead: 0` does not
 prove a branch is pushed when it has no upstream.
+
+### Staying up to date
+
+```bash
+gitpulse --update          # check PyPI, then upgrade in place
+gitpulse --check-update    # report only — installs nothing
+```
+
+`--update` detects how GitPulse was installed and runs the right command for
+that channel. It will **not** upgrade in place when doing so would break the
+install — it prints the correct command instead:
+
+| Install method | Behaviour |
+|---|---|
+| virtualenv | upgrades in place with `pip` |
+| pipx | runs `pipx upgrade gitpulse-tui` |
+| npm | prints `npm install -g gitpulse-tui@latest` |
+| OS-managed Python ([PEP 668](https://peps.python.org/pep-0668/)) | prints a `pipx` command |
+
+npm installs are deliberately excluded from self-upgrade: the wrapper pins an
+exact Python package version and would silently revert a `pip` upgrade on the
+next launch.
+
+GitPulse never checks for updates on its own — no background network calls, no
+telemetry. The check happens only when you ask for it.
 
 ## Features
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,26 @@ Project activity log. Newest on top.
 
 ---
 
+## [2026-08-09 16:45] — Added `gitpulse --update` self-upgrade
+
+**What:** `--update` checks PyPI for a newer release and upgrades in place;
+`--check-update` reports without installing. `gitpulse/update.py` detects the
+install channel (venv / pipx / npm wrapper / OS-managed Python) and either runs
+the correct command or prints it.
+
+**Why:** Requested. The complication is that GitPulse ships through two
+channels — the npm wrapper bootstraps its own venv at `~/.gitpulse/venv` and
+pins an exact `gitpulse-tui==X.Y.Z`, so a pip upgrade there is silently
+reverted on the next launch. PEP 668 interpreters must not be written to at
+all. A blind `pip install --upgrade` would have broken both.
+
+**State:** DONE — verified with a real 1.2.15 → 1.2.16 upgrade in a throwaway
+venv; 17 new tests (191 → 208), all offline (verified with `urlopen` blocked).
+
+**Next:** —
+
+---
+
 ## [2026-08-07 15:40] — Fleet overhaul: UI fixes, agent surface, release safety
 
 **What:** Single branch `feat/fleet-overhaul` closing GitHub issues #26–#37

--- a/gitpulse/cli.py
+++ b/gitpulse/cli.py
@@ -35,6 +35,8 @@ examples:
   gitpulse context                    fleet state as Markdown, for an LLM prompt
   gitpulse digest --since 7d          what you committed in the last week
 
+  gitpulse --update                   check PyPI and upgrade to the latest release
+
 dashboard keys:
   /  filter repos          j / k or arrows  move            [ ]  switch tab
   r  rescan                Space / *        select / all    :    bulk actions
@@ -124,6 +126,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--version", action="version", version=f"gitpulse {__version__}"
+    )
+    parser.add_argument(
+        "--update", action="store_true", default=False,
+        help="Check PyPI for a newer release and upgrade in place",
+    )
+    parser.add_argument(
+        "--check-update", action="store_true", default=False,
+        help="Report whether a newer release exists, without installing it",
     )
 
     def add_common(target: argparse.ArgumentParser) -> None:
@@ -316,6 +326,13 @@ def main() -> None:
     """Console-script entry point."""
     parser = _build_parser()
     args = parser.parse_args()
+
+    # Update checks talk to the network and touch no repos, so handle them
+    # before config loading or anything that would launch the TUI.
+    if getattr(args, "update", False) or getattr(args, "check_update", False):
+        from .update import run_update
+
+        sys.exit(run_update(check_only=args.check_update))
 
     # Load config before anything reads scan roots or worker counts.
     if getattr(args, "config", None):

--- a/gitpulse/update.py
+++ b/gitpulse/update.py
@@ -1,0 +1,236 @@
+"""
+update.py — Version check and self-upgrade for GitPulse.
+
+GitPulse ships through two channels: PyPI (pip / pipx) and npm, where a thin
+wrapper bootstraps its own virtualenv at ``~/.gitpulse/venv`` and pins an exact
+version. A single upgrade command cannot serve both — pip-upgrading inside the
+npm wrapper's venv would be silently undone the next time the wrapper runs and
+re-pinned the version recorded in its ``state.json``.
+
+So this module detects *how* GitPulse was installed and either runs the right
+command or prints it, rather than guessing and leaving a broken install.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import sysconfig
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from .utils import __version__
+
+PYPI_JSON_URL = "https://pypi.org/pypi/gitpulse-tui/json"
+PACKAGE = "gitpulse-tui"
+
+# Install methods, in the order they are probed.
+NPM = "npm"
+PIPX = "pipx"
+VENV = "venv"
+SYSTEM = "system"
+
+
+@dataclass
+class Install:
+    """How this GitPulse was installed, and how to upgrade it."""
+
+    method: str
+    #: Command to run for an in-place upgrade, or None if unsafe to self-run.
+    command: list[str] | None
+    #: What to tell the user when we will not run the upgrade ourselves.
+    manual_hint: str
+    #: Human-readable location, for display.
+    location: str
+
+
+def _npm_venv_root() -> Path:
+    """The venv the npm wrapper manages (``~/.gitpulse/venv``)."""
+    return Path.home() / ".gitpulse" / "venv"
+
+
+def detect_install() -> Install:
+    """Work out how this interpreter's GitPulse was installed."""
+    exe = Path(sys.executable).resolve()
+    prefix = Path(sys.prefix).resolve()
+
+    # npm wrapper — its venv is re-pinned from npm/package.json on every
+    # launch, so upgrading the Python package alone would be reverted.
+    try:
+        npm_root = _npm_venv_root().resolve()
+        if prefix == npm_root or npm_root in exe.parents:
+            return Install(
+                method=NPM,
+                command=None,
+                manual_hint=(
+                    "Installed via npm. Upgrade with:\n"
+                    "    npm install -g gitpulse-tui@latest\n\n"
+                    "The npm wrapper pins an exact Python package version, so "
+                    "upgrading\nit with pip alone would be undone on the next "
+                    "launch."
+                ),
+                location=str(npm_root),
+            )
+    except OSError:
+        pass
+
+    # pipx — each app gets its own venv under PIPX_HOME (or ~/.local/pipx).
+    pipx_home = os.environ.get("PIPX_HOME")
+    pipx_roots = [Path(pipx_home)] if pipx_home else []
+    pipx_roots += [Path.home() / ".local" / "pipx", Path.home() / ".local" / "share" / "pipx"]
+    for root in pipx_roots:
+        try:
+            if root.resolve() in prefix.parents:
+                return Install(
+                    method=PIPX,
+                    command=["pipx", "upgrade", PACKAGE],
+                    manual_hint=f"    pipx upgrade {PACKAGE}",
+                    location=str(prefix),
+                )
+        except OSError:
+            continue
+
+    # A regular virtualenv — safe to upgrade in place with this interpreter.
+    if sys.prefix != sys.base_prefix:
+        return Install(
+            method=VENV,
+            command=[
+                sys.executable, "-m", "pip", "install", "--upgrade",
+                "--quiet", "--disable-pip-version-check", PACKAGE,
+            ],
+            manual_hint=f"    {sys.executable} -m pip install --upgrade {PACKAGE}",
+            location=str(prefix),
+        )
+
+    # System / user install. PEP 668 marks distro-managed interpreters where
+    # pip should not write; never run an upgrade against those.
+    externally_managed = Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED"
+    if externally_managed.exists():
+        return Install(
+            method=SYSTEM,
+            command=None,
+            manual_hint=(
+                "This Python is managed by your operating system, so GitPulse "
+                "will not\nmodify it. Install into an isolated environment "
+                "instead:\n"
+                f"    pipx install --force {PACKAGE}"
+            ),
+            location=str(prefix),
+        )
+
+    return Install(
+        method=SYSTEM,
+        command=[
+            sys.executable, "-m", "pip", "install", "--upgrade",
+            "--quiet", "--disable-pip-version-check", PACKAGE,
+        ],
+        manual_hint=f"    {sys.executable} -m pip install --upgrade {PACKAGE}",
+        location=str(prefix),
+    )
+
+
+def fetch_latest_version(timeout: float = 5.0) -> str:
+    """Return the newest version of *gitpulse-tui* published on PyPI.
+
+    Raises:
+        URLError: the network call failed or timed out.
+        ValueError: PyPI returned something unparseable.
+    """
+    request = Request(
+        PYPI_JSON_URL,
+        headers={"User-Agent": f"gitpulse/{__version__}"},
+    )
+    with urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed https URL
+        payload = json.load(response)
+    try:
+        return str(payload["info"]["version"])
+    except (KeyError, TypeError) as exc:
+        raise ValueError("unexpected response from PyPI") from exc
+
+
+def _version_tuple(version: str) -> tuple:
+    """Parse a version into integer components for comparison.
+
+    Non-numeric suffixes are truncated, so ``1.2.3rc1`` compares equal to
+    ``1.2.3`` rather than before it. GitPulse's release pipeline only ever
+    publishes plain ``X.Y.Z``, so this is not worth a full PEP 440 parser; the
+    consequence of the simplification is that a pre-release is never reported
+    as an available upgrade.
+    """
+    parts: list[int] = []
+    for chunk in version.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def is_newer(latest: str, current: str) -> bool:
+    """True if *latest* is a strictly greater version than *current*."""
+    return _version_tuple(latest) > _version_tuple(current)
+
+
+def run_update(check_only: bool = False) -> int:
+    """Compare the installed version against PyPI and upgrade if possible.
+
+    Returns a process exit code.
+    """
+    print(f"gitpulse {__version__} (installed)")
+
+    try:
+        latest = fetch_latest_version()
+    except URLError as exc:
+        print(f"Error: could not reach PyPI — {exc.reason}", file=sys.stderr)
+        return 1
+    except (ValueError, TimeoutError, OSError) as exc:
+        print(f"Error: could not check for updates — {exc}", file=sys.stderr)
+        return 1
+
+    if not is_newer(latest, __version__):
+        if latest != __version__:
+            # Ahead of PyPI — an editable checkout or a pre-release.
+            print(f"gitpulse {latest} is the latest published release.")
+            print("You are running a newer or unpublished build.")
+        else:
+            print("Already up to date.")
+        return 0
+
+    print(f"gitpulse {latest} is available.")
+
+    install = detect_install()
+
+    if check_only or install.command is None:
+        print()
+        if install.command is None:
+            print(install.manual_hint)
+        else:
+            print("Upgrade with:")
+            print(install.manual_hint)
+        return 0
+
+    print(f"Upgrading via {install.method} at {install.location} …")
+
+    try:
+        result = subprocess.run(install.command, check=False)
+    except OSError as exc:
+        print(f"Error: could not run the upgrade — {exc}", file=sys.stderr)
+        print("Run it manually:", file=sys.stderr)
+        print(install.manual_hint, file=sys.stderr)
+        return 1
+
+    if result.returncode != 0:
+        print(file=sys.stderr)
+        print("Upgrade failed. Run it manually:", file=sys.stderr)
+        print(install.manual_hint, file=sys.stderr)
+        return result.returncode
+
+    print()
+    print(f"Upgraded to gitpulse {latest}. Restart gitpulse to use it.")
+    return 0

--- a/skills/gitpulse/SKILL.md
+++ b/skills/gitpulse/SKILL.md
@@ -18,6 +18,11 @@ If this fails, GitPulse is not installed. Tell the user:
 `pip install gitpulse-tui` (or `pipx install gitpulse-tui`). Do not attempt to
 install it yourself unless asked.
 
+If a command fails in a way that suggests an old version (an unrecognised flag,
+a missing field), `gitpulse --check-update` reports whether a newer release
+exists without installing anything. **Do not run `gitpulse --update` unless the
+user asks** — it modifies their environment.
+
 ## The one command that matters
 
 ```bash

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,182 @@
+"""
+Coverage for the self-update path.
+
+Network access is always stubbed — these tests never reach PyPI, and never run
+a real installer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.error import URLError
+
+import pytest
+
+from gitpulse import update as up
+from gitpulse.update import Install, is_newer, run_update
+
+
+class TestVersionComparison:
+    @pytest.mark.parametrize(
+        "latest,current,expected",
+        [
+            ("1.2.16", "1.2.15", True),
+            ("1.2.15", "1.2.15", False),
+            ("1.2.15", "1.2.16", False),
+            ("1.2.10", "1.2.9", True),      # numeric, not lexicographic
+            ("1.10.0", "1.9.0", True),
+            ("2.0.0", "1.9.9", True),
+            ("1.3.0", "1.2.99", True),
+        ],
+    )
+    def test_is_newer(self, latest, current, expected):
+        assert is_newer(latest, current) is expected
+
+    def test_shorter_version_is_not_newer(self):
+        assert is_newer("1.2", "1.2.1") is False
+
+
+class TestDetectInstall:
+    def test_venv_is_upgradable_in_place(self, monkeypatch):
+        # Arrange — look like a virtualenv, and not like npm/pipx
+        monkeypatch.setattr(up.sys, "prefix", "/tmp/venv")
+        monkeypatch.setattr(up.sys, "base_prefix", "/usr")
+        monkeypatch.setattr(up, "_npm_venv_root", lambda: Path("/nonexistent"))
+
+        # Act
+        install = up.detect_install()
+
+        # Assert
+        assert install.method == up.VENV
+        assert install.command is not None
+        assert "--upgrade" in install.command
+
+    def test_npm_install_refuses_to_self_upgrade(self, monkeypatch, tmp_path):
+        """pip-upgrading the npm venv would be undone on the next launch."""
+        # Arrange — pretend this interpreter lives in the npm-managed venv
+        npm_root = tmp_path / "venv"
+        npm_root.mkdir()
+        monkeypatch.setattr(up, "_npm_venv_root", lambda: npm_root)
+        monkeypatch.setattr(up.sys, "prefix", str(npm_root))
+
+        # Act
+        install = up.detect_install()
+
+        # Assert
+        assert install.method == up.NPM
+        assert install.command is None
+        assert "npm install -g gitpulse-tui@latest" in install.manual_hint
+
+    def test_externally_managed_python_is_not_touched(self, monkeypatch, tmp_path):
+        """PEP 668 marks distro Pythons where pip must not write."""
+        # Arrange — not a venv, not npm, and marked externally managed
+        monkeypatch.setattr(up.sys, "prefix", "/usr")
+        monkeypatch.setattr(up.sys, "base_prefix", "/usr")
+        monkeypatch.setattr(up, "_npm_venv_root", lambda: Path("/nonexistent"))
+        (tmp_path / "EXTERNALLY-MANAGED").write_text("")
+        monkeypatch.setattr(
+            up.sysconfig, "get_path", lambda name: str(tmp_path)
+        )
+
+        # Act
+        install = up.detect_install()
+
+        # Assert
+        assert install.method == up.SYSTEM
+        assert install.command is None
+        assert "pipx" in install.manual_hint
+
+
+class TestRunUpdate:
+    def test_reports_already_up_to_date(self, monkeypatch, capsys):
+        # Arrange
+        monkeypatch.setattr(up, "__version__", "1.2.16")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "1.2.16")
+
+        # Act
+        code = run_update()
+
+        # Assert
+        assert code == 0
+        assert "Already up to date" in capsys.readouterr().out
+
+    def test_network_failure_exits_nonzero(self, monkeypatch, capsys):
+        # Arrange
+        def boom(timeout=5.0):
+            raise URLError("no route to host")
+
+        monkeypatch.setattr(up, "fetch_latest_version", boom)
+
+        # Act
+        code = run_update()
+
+        # Assert
+        assert code == 1
+        assert "could not reach PyPI" in capsys.readouterr().err
+
+    def test_check_only_never_runs_a_command(self, monkeypatch, capsys):
+        # Arrange
+        ran = []
+        monkeypatch.setattr(up, "__version__", "1.0.0")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "9.9.9")
+        monkeypatch.setattr(up.subprocess, "run", lambda *a, **k: ran.append(a))
+
+        # Act
+        code = run_update(check_only=True)
+
+        # Assert
+        assert code == 0
+        assert ran == []
+        assert "9.9.9 is available" in capsys.readouterr().out
+
+    def test_unsupported_channel_prints_manual_hint_only(self, monkeypatch, capsys):
+        # Arrange — an install we refuse to upgrade ourselves
+        ran = []
+        monkeypatch.setattr(up, "__version__", "1.0.0")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "9.9.9")
+        monkeypatch.setattr(up.subprocess, "run", lambda *a, **k: ran.append(a))
+        monkeypatch.setattr(
+            up, "detect_install",
+            lambda: Install(up.NPM, None, "    npm install -g gitpulse-tui@latest", "/x"),
+        )
+
+        # Act
+        code = run_update()
+
+        # Assert
+        assert code == 0
+        assert ran == []
+        assert "npm install -g" in capsys.readouterr().out
+
+    def test_failed_upgrade_surfaces_the_manual_command(self, monkeypatch, capsys):
+        # Arrange
+        class Failed:
+            returncode = 1
+
+        monkeypatch.setattr(up, "__version__", "1.0.0")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "9.9.9")
+        monkeypatch.setattr(up.subprocess, "run", lambda *a, **k: Failed())
+        monkeypatch.setattr(
+            up, "detect_install",
+            lambda: Install(up.VENV, ["false"], "    pip install -U gitpulse-tui", "/x"),
+        )
+
+        # Act
+        code = run_update()
+
+        # Assert
+        assert code == 1
+        assert "pip install -U gitpulse-tui" in capsys.readouterr().err
+
+    def test_running_ahead_of_pypi_is_not_an_error(self, monkeypatch, capsys):
+        """An editable checkout is often newer than the published release."""
+        # Arrange
+        monkeypatch.setattr(up, "__version__", "2.0.0")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "1.2.16")
+
+        # Act
+        code = run_update()
+
+        # Assert
+        assert code == 0
+        assert "newer or unpublished" in capsys.readouterr().out


### PR DESCRIPTION
Adds `gitpulse --update` (check PyPI, upgrade in place) and `gitpulse --check-update` (report only, install nothing).

## Why this isn't just `pip install --upgrade`

That was my first instinct too, and it would have broken two of the four install paths.

**npm installs would silently revert.** The npm wrapper bootstraps its own venv at `~/.gitpulse/venv` and pins an exact `gitpulse-tui==X.Y.Z` matching the npm package version (`npm/lib/install.js`). Pip-upgrading inside that venv works — until the next launch, when the wrapper reads `state.json`, sees a version mismatch, and reinstalls the old pin. The user would "update" and stay on the same version with no error.

**PEP 668 interpreters must not be written to.** Distro-managed Pythons carry an `EXTERNALLY-MANAGED` marker; pip refuses by design, and forcing past it damages the system install.

So `gitpulse/update.py` detects the channel and either runs the right command or prints it:

| Detected | Behaviour |
|---|---|
| virtualenv | upgrades in place with `pip --quiet` |
| pipx | runs `pipx upgrade gitpulse-tui` |
| npm | **refuses**, prints `npm install -g gitpulse-tui@latest` |
| OS-managed (PEP 668) | **refuses**, prints a `pipx` command |

A failed upgrade exits non-zero with the manual command on stderr, so it never leaves you guessing.

## Design notes

- **No background version checks.** The network is touched only when you ask. Startup stays offline-safe and nothing phones home — this matters for a CLI that agents also invoke.
- **`--quiet` on pip.** The default output dumps the full dependency-resolution wall, which is noise for a self-upgrade.
- **Running ahead of PyPI is reported, not an error** — an editable checkout is routinely newer than the published release.
- **Version comparison is numeric**, so `1.2.10` correctly beats `1.2.9` (a string compare gets this wrong). It truncates non-numeric suffixes rather than implementing PEP 440. The release pipeline only ever publishes plain `X.Y.Z`, so the documented consequence — a pre-release is never offered as an upgrade — is the correct behaviour here anyway.

## Agent-facing docs

The skill and `AGENTS.md` now say to use `--check-update` when a flag or field looks missing, and **explicitly not to run `--update` unprompted**, since it modifies the user's environment.

## Verification

- **A real upgrade, not a mock:** installed 1.2.15 in a throwaway venv, ran `--update`, confirmed it fetched and installed 1.2.16 and that `--version` reflected it afterwards.
- Exercised every detection branch (npm, pipx, venv, PEP 668) and both failure paths (network down, installer exits non-zero).
- **Confirmed the test suite is genuinely offline** by re-running `test_update.py` with `urllib.request.urlopen` hard-blocked — 17 passed, so nothing reaches PyPI or runs a real installer during tests.

Tests: 191 → **208**.

## Known limitation

`--update` can't help anyone on ≤1.2.15, since the flag doesn't exist there — `gitpulse --update` on 1.2.15 exits 2 with "unrecognized arguments". Those users need one manual `pip install --upgrade gitpulse-tui` first. Unavoidable bootstrap problem with any self-update feature; worth a line in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
