### PR TITLE
fix(install): symlink instead of shell alias, and recover the lost npm stderr fix

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -159,3 +159,31 @@ npm's own suggested `npm install -g --allow-scripts=gitpulse-tui` fails with
 **Verified:** Same scenario now yields valid JSON (`repo_count 1300`) with the
 explanation on stderr. `tests/test_npm_wrapper.py` guards it — confirmed the
 test fails when `log()` is reverted to stdout.
+
+---
+
+## 2026-08-09 — install.sh alias broke when the checkout moved
+
+**Symptom:** `gitpulse` resolved to
+`/home/lebi/projects/git-tui/.venv/bin/python -m gitpulse` — a venv that no
+longer existed — shadowing a working `/usr/bin/gitpulse` from npm. The shell
+reported the alias, so `which gitpulse` looked fine while every invocation
+failed.
+
+**Root cause:** `install.sh:52` wrote `alias gitpulse="<abs path> -m gitpulse"`
+into `.bashrc`, `.zshrc`, and `.bash_profile`. An absolute path baked into rc
+files breaks silently when the repo is moved or deleted, takes precedence over
+any pip/pipx/npm install, and never applied to fish at all.
+
+**Fix:** `install.sh:48` — symlink the venv's console script into
+`~/.local/bin` instead, which works in bash, zsh, and fish, and dies with the
+checkout rather than outliving it. The installer also strips the old alias if
+it finds one, and warns when `~/.local/bin` is not on PATH.
+`uninstall.sh:46` removes the symlink, guarding with a literal `readlink` so it
+only deletes a link pointing into this checkout.
+
+**Verified:** Full install → uninstall cycle in a sandboxed `HOME`, including a
+pre-seeded stale alias (removed) and a foreign `~/.local/bin/gitpulse` pointing
+at `/usr/bin/gitpulse` (correctly left in place). The `readlink -f` variant was
+caught failing during that test — `.venv` is deleted first, so the link is
+dangling and `-f` returned empty, skipping removal.

--- a/FIXES.md
+++ b/FIXES.md
@@ -133,3 +133,29 @@ each list now passes a subtitle describing only itself ("Press s on a file to
 stage it", etc.).
 
 **Verified:** Screenshot against a repo with untracked files.
+
+---
+
+## 2026-08-09 — npm wrapper corrupted `gitpulse scan --json`
+
+**Symptom:** After `npm install -g gitpulse-tui@latest`, the first `gitpulse`
+command printed venv bootstrap logs before its real output. Piping that run —
+`gitpulse scan --json > fleet.json` — produced invalid JSON, breaking the
+documented contract that stdout carries only JSON.
+
+**Root cause:** npm blocks postinstall scripts by default now, so the Python
+venv stays on the previous version. The launcher self-heals on next run, but
+`log()` in `npm/lib/install.js:24` wrote progress to **stdout**, mixing it into
+the command's output. Reproduced by clearing `~/.gitpulse/state.json` and
+running `gitpulse scan --json` — `json.load` failed at char 0.
+
+**Fix:** `npm/lib/install.js:23` — `log()` now writes to stderr. Added a notice
+naming the version mismatch and the blocked postinstall, so a mid-command
+bootstrap explains itself instead of appearing as an unexplained wall of output.
+`npm/README.md` documents the "install scripts blocked" warning, including that
+npm's own suggested `npm install -g --allow-scripts=gitpulse-tui` fails with
+`Cannot destructure property 'name' of '.for'` when no package is named.
+
+**Verified:** Same scenario now yields valid JSON (`repo_count 1300`) with the
+explanation on stderr. `tests/test_npm_wrapper.py` guards it — confirmed the
+test fails when `log()` is reverted to stdout.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ The installer:
 - Checks your Python version (3.10+ required)
 - Creates a virtual environment automatically
 - Installs all dependencies
-- Adds the `gitpulse` command to your shell (`~/.zshrc` / `~/.bashrc`)
+- Symlinks `gitpulse` into `~/.local/bin` (works in bash, zsh, and fish)
 
-Then reload your shell:
-```bash
-source ~/.zshrc   # or source ~/.bashrc
-```
+If `~/.local/bin` is not already on your `PATH`, the installer tells you how to
+add it. Run `./uninstall.sh` to reverse all of it.
+
+> Earlier versions wrote a shell alias into `~/.bashrc` and `~/.zshrc` with an
+> absolute path to the checkout. That broke silently if the repo was moved or
+> deleted, and shadowed any pip/pipx/npm install of GitPulse. The installer now
+> removes that alias if it finds one.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,6 @@ set -e
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV="$REPO_DIR/.venv"
-BIN="$VENV/bin/python"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -46,40 +45,48 @@ echo -e "${YELLOW}▸ Installing dependencies...${NC}"
 "$VENV/bin/pip" install --quiet -e "$REPO_DIR"
 echo -e "   ${GREEN}✓ Installed textual, rich, gitpython${NC}"
 
-# ── 4. Detect shell and add alias ──────────────────────────────────────────
-echo -e "${YELLOW}▸ Adding 'gitpulse' command to your shell...${NC}"
+# ── 4. Expose the `gitpulse` command ───────────────────────────────────────
+# The venv already provides a console script. Symlinking it into a directory
+# on PATH is better than writing an alias into rc files: an alias hardcodes an
+# absolute path that silently breaks if the checkout is moved or deleted, and
+# it shadows any other GitPulse install (pip, pipx, npm) for the whole shell.
+echo -e "${YELLOW}▸ Exposing the 'gitpulse' command...${NC}"
 
-ALIAS_LINE="alias gitpulse=\"$BIN -m gitpulse\""
+CONSOLE_SCRIPT="$VENV/bin/gitpulse"
+LINK_DIR="$HOME/.local/bin"
+LINK="$LINK_DIR/gitpulse"
 
-# Write to every rc file that exists (covers bash, zsh, and both at once)
-RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile")
+mkdir -p "$LINK_DIR"
+ln -sf "$CONSOLE_SCRIPT" "$LINK"
+echo -e "   ${GREEN}✓ Linked $LINK → .venv/bin/gitpulse${NC}"
 
-for RC in "${RC_FILES[@]}"; do
+# Remove aliases written by older versions of this installer; they point at an
+# absolute path and would take precedence over the symlink.
+for RC in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile"; do
     [[ -f "$RC" ]] || continue
     if grep -q "alias gitpulse=" "$RC" 2>/dev/null; then
-        sed -i "s|alias gitpulse=.*|$ALIAS_LINE|" "$RC"
-        echo -e "   ${GREEN}✓ Updated alias in $(basename $RC)${NC}"
-    else
-        echo "" >> "$RC"
-        echo "# GitPulse TUI" >> "$RC"
-        echo "$ALIAS_LINE" >> "$RC"
-        echo -e "   ${GREEN}✓ Added alias to $(basename $RC)${NC}"
+        sed -i '/^# GitPulse TUI$/d; /alias gitpulse=/d' "$RC"
+        echo -e "   ${GREEN}✓ Removed the old alias from $(basename "$RC")${NC}"
     fi
 done
+
+if ! echo ":$PATH:" | grep -q ":$LINK_DIR:"; then
+    echo -e "   ${YELLOW}! $LINK_DIR is not on your PATH${NC}"
+    echo -e "     bash/zsh:  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+    echo -e "     fish:      fish_add_path ~/.local/bin"
+fi
 
 # ── 5. Done ────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}${GREEN}✅ GitPulse installed successfully!${NC}"
 echo ""
-echo -e "  ${BOLD}Reload your shell, then run:${NC}"
+echo -e "  ${BOLD}Run it with:${NC}"
 echo ""
 echo -e "   ${CYAN}gitpulse${NC}                         # scans current directory"
 echo -e "   ${CYAN}gitpulse --root /path/to/repos${NC}   # scans a custom dir"
 echo -e "   ${CYAN}gitpulse --commits 20${NC}            # show more commits"
 echo ""
-echo -e "  ${BOLD}Or reload now with:${NC}"
-echo -e "   ${CYAN}source ~/.bashrc${NC}   # bash users"
-echo -e "   ${CYAN}source ~/.zshrc${NC}    # zsh users"
+echo -e "  ${BOLD}Keybindings (press ? in the app for the full sheet):${NC}"
 echo ""
 echo -e "  ${BOLD}Global:${NC}       ↑↓ navigate  /  search  r  refresh  q  quit"
 echo -e "  ${BOLD}Status tab:${NC}   s  stage    u  unstage    a  stage-all    c  commit"

--- a/npm/README.md
+++ b/npm/README.md
@@ -67,9 +67,38 @@ gitpulse <args>
 The npm and PyPI versions are kept in lockstep by CI: npm `vX.Y.Z` always
 installs `gitpulse-tui==X.Y.Z`.
 
-If the npm `postinstall` step cannot complete (e.g. offline), it does **not**
-fail the install — the launcher automatically retries the setup the first time
-you run `gitpulse`.
+If the npm `postinstall` step cannot complete, it does **not** fail the install
+— the launcher retries the setup the first time you run `gitpulse`. Progress is
+printed to stderr, so `gitpulse scan --json > out.json` stays valid even when
+the bootstrap runs mid-command.
+
+### "1 package had install scripts blocked"
+
+Recent npm versions block install scripts by default, so you may see:
+
+```
+npm warn install-scripts   gitpulse-tui@X.Y.Z (postinstall: node scripts/postinstall.js)
+```
+
+**This is safe to ignore.** The Python runtime is set up automatically the next
+time you run `gitpulse` — you will see a one-line notice while it finishes.
+
+To let the postinstall run at install time instead, append the flag to a real
+install command:
+
+```bash
+npm install -g --allow-scripts=gitpulse-tui gitpulse-tui@latest
+```
+
+Note that `npm install -g --allow-scripts=gitpulse-tui` **on its own**, with no
+package named, fails with `Cannot destructure property 'name' of '.for'` — npm's
+own warning text omits the package argument.
+
+To allow it permanently:
+
+```bash
+npm config set allow-scripts=gitpulse-tui --location=user
+```
 
 ## Environment variables
 

--- a/npm/lib/install.js
+++ b/npm/lib/install.js
@@ -20,8 +20,16 @@ const PYPI_PACKAGE = "gitpulse-tui";
 /** Error subclass carrying a pre-formatted, user-facing remediation message. */
 class InstallError extends Error {}
 
+/**
+ * Progress goes to stderr, never stdout.
+ *
+ * `gitpulse scan --json` guarantees that stdout carries only JSON, and this
+ * bootstrap can run mid-command the first time after an npm upgrade (npm may
+ * block the postinstall hook). Writing progress to stdout corrupts that output
+ * and breaks any consumer parsing it.
+ */
 function log(line) {
-  process.stdout.write(`${line}\n`);
+  process.stderr.write(`${line}\n`);
 }
 
 function readState() {
@@ -127,6 +135,18 @@ function ensurePythonPackage(opts) {
     if (state && state.installedVersion === targetVersion && venvPythonExists()) {
       return venvPython();
     }
+  }
+
+  // Reaching here mid-command means the postinstall hook did not run — npm
+  // blocks install scripts unless allow-scripts covers the package. Say so,
+  // rather than dumping install output with no explanation.
+  const state = readState();
+  if (state && state.installedVersion !== targetVersion) {
+    log(
+      `▸ GitPulse ${targetVersion} was installed, but its Python runtime is ` +
+        `still on ${state.installedVersion}.`,
+    );
+    log("  Finishing setup now (npm blocked the postinstall step) …");
   }
 
   // Locate a host interpreter to bootstrap the venv.

--- a/tests/test_npm_wrapper.py
+++ b/tests/test_npm_wrapper.py
@@ -1,0 +1,69 @@
+"""
+Guards on the npm launcher's output discipline.
+
+The wrapper bootstraps its Python venv lazily, which means the bootstrap can
+run *mid-command* the first time after an npm upgrade (npm blocks postinstall
+scripts by default). If that progress output goes to stdout it corrupts
+`gitpulse scan --json`, whose documented contract is that stdout carries only
+JSON.
+
+These are static checks rather than a node test suite: the repo has no npm test
+harness, and the property worth protecting is simply "never write progress to
+stdout".
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+NPM_LIB = Path(__file__).resolve().parent.parent / "npm" / "lib"
+NPM_BIN = Path(__file__).resolve().parent.parent / "npm" / "bin"
+NPM_SCRIPTS = Path(__file__).resolve().parent.parent / "npm" / "scripts"
+
+
+def _js_sources() -> list[Path]:
+    files = list(NPM_LIB.glob("*.js")) + list(NPM_BIN.glob("*.js"))
+    files += list(NPM_SCRIPTS.glob("*.js"))
+    return [f for f in files if f.is_file()]
+
+
+@pytest.mark.skipif(not NPM_LIB.is_dir(), reason="npm wrapper not present")
+class TestWrapperWritesProgressToStderr:
+    def test_no_js_file_writes_to_stdout(self):
+        """Progress must go to stderr so piped JSON stays parseable."""
+        offenders = []
+        for path in _js_sources():
+            for lineno, line in enumerate(path.read_text().splitlines(), 1):
+                if "process.stdout.write" in line:
+                    offenders.append(f"{path.name}:{lineno}")
+
+        assert not offenders, (
+            "npm wrapper writes to stdout at "
+            + ", ".join(offenders)
+            + " — this corrupts `gitpulse scan --json`. Use process.stderr."
+        )
+
+    def test_install_log_helper_targets_stderr(self):
+        # Arrange
+        source = (NPM_LIB / "install.js").read_text()
+
+        # Act — locate the log() helper body
+        match = re.search(r"function log\(line\) \{(.*?)\}", source, re.S)
+
+        # Assert
+        assert match, "install.js no longer defines a log() helper"
+        assert "process.stderr.write" in match.group(1)
+
+    def test_bootstrap_explains_itself(self):
+        """A silent wall of install output mid-command is not acceptable UX."""
+        # Arrange
+        source = (NPM_LIB / "install.js").read_text()
+
+        # Assert
+        assert "postinstall" in source, (
+            "install.js should explain that npm blocked the postinstall step "
+            "when it bootstraps mid-command"
+        )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -43,7 +43,30 @@ find "$REPO_DIR" -maxdepth 3 -name "*.egg-info" -type d -exec rm -rf {} + 2>/dev
 find "$REPO_DIR" -maxdepth 3 -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
 echo -e "   ${GREEN}✓ Cleaned build artifacts${NC}"
 
-# ── 3. Remove alias/PATH from shell rc files ───────────────────────────────
+# ── 3. Remove the console-script symlink ───────────────────────────────────
+echo -e "${YELLOW}▸ Removing the 'gitpulse' command...${NC}"
+
+LINK="$HOME/.local/bin/gitpulse"
+if [[ -L "$LINK" ]]; then
+    # Only remove a symlink that points into this checkout, so a pip/pipx
+    # install of gitpulse living at the same path is left alone.
+    #
+    # Read the link literally rather than with `readlink -f`: step 1 has
+    # already deleted .venv, so the link is dangling and -f would resolve to
+    # an empty string, causing this check to skip the very link it created.
+    TARGET="$(readlink "$LINK" 2>/dev/null || true)"
+    case "$TARGET" in
+        "$REPO_DIR"/*)
+            rm -f "$LINK"
+            echo -e "   ${GREEN}✓ Removed $LINK${NC}"
+            ;;
+        *)
+            echo -e "   ${YELLOW}! $LINK points outside this checkout — left in place${NC}"
+            ;;
+    esac
+fi
+
+# ── 4. Remove alias/PATH from shell rc files ───────────────────────────────
 echo -e "${YELLOW}▸ Removing shell configuration...${NC}"
 
 RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile")
@@ -62,7 +85,7 @@ for RC in "${RC_FILES[@]}"; do
     fi
 done
 
-# ── 4. Done ────────────────────────────────────────────────────────────────
+# ── 5. Done ────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}${GREEN}✅ GitPulse uninstalled successfully!${NC}"
 echo ""


### PR DESCRIPTION
Two fixes, both found by using GitPulse on a real machine rather than reading the code.

## 1. `install.sh` wrote a shell alias with a hardcoded absolute path

```bash
alias gitpulse="/home/lebi/projects/git-tui/.venv/bin/python -m gitpulse"
```

That venv no longer existed. The alias shadowed a perfectly good `/usr/bin/gitpulse` from the npm install, and because `which gitpulse` dutifully reported the alias, the command *looked* installed while every invocation failed.

Three problems with the approach, all hit in practice:

- **The absolute path breaks silently** when the checkout is moved or deleted
- **It shadows any pip / pipx / npm install** of GitPulse for the whole shell
- **It never covered fish** — only `.bashrc`, `.zshrc`, `.bash_profile`

**Fix:** symlink the venv's console script into `~/.local/bin`. Works in bash, zsh and fish alike, and it dies with the checkout instead of outliving it. The installer now also strips the old alias when it finds one, and warns if `~/.local/bin` isn't on `PATH`.

`uninstall.sh` removes the symlink — but **only when it points into this checkout**, so a pipx or npm install sitting at the same path is left alone.

### A bug I introduced and caught by actually running it

My first version of that guard used `readlink -f`. It silently failed to remove anything: `.venv` is deleted in an earlier step, so the link is already dangling and `-f` resolves to an empty string, which meant the `$REPO_DIR/*` match never fired — the guard skipped the very link the installer created. Plain `readlink` reads the link literally and works on a dangling link.

Verified with a full install → uninstall cycle in a sandboxed `HOME`:

| Scenario | Result |
|---|---|
| pre-seeded stale alias in `.bashrc` | removed |
| symlink created and runnable | `gitpulse 1.2.16` |
| uninstall with dangling link | removed |
| foreign `~/.local/bin/gitpulse` → `/usr/bin/gitpulse` | **left in place** |

## 2. Cherry-picks the npm stderr fix that was lost

`d81c31c` never made it onto `main` — #40 was merged before that commit was pushed, so the fix is currently missing from the released 1.2.17. Confirmed with `git merge-base --is-ancestor d81c31c origin/main` → not an ancestor.

That's the one where the npm wrapper's bootstrap logs went to **stdout**, so the first `gitpulse scan --json` after any npm upgrade returned invalid JSON — breaking the contract the README, the skill, and `AGENTS.md` all promise. Details in the [#40 comment](https://github.com/lebiraja/gitpulse/pull/40#issuecomment-5231304931).

It brings `tests/test_npm_wrapper.py` with it (208 → 211 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
