### PR TITLE
fix(update): --update now performs the npm upgrade instead of printing it

### DIFF
--- a/gitpulse/update.py
+++ b/gitpulse/update.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -53,25 +54,83 @@ def _npm_venv_root() -> Path:
     return Path.home() / ".gitpulse" / "venv"
 
 
+def _npm_global_root() -> Path | None:
+    """Return npm's global node_modules directory, or None if npm is absent."""
+    npm = shutil.which("npm")
+    if npm is None:
+        return None
+    try:
+        result = subprocess.run(
+            [npm, "root", "-g"],
+            capture_output=True, text=True, timeout=20, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip())
+
+
+def _npm_upgrade_command() -> list[str] | None:
+    """Build the command that upgrades the global npm package.
+
+    Global npm prefixes are frequently root-owned, so the install needs sudo.
+    Since ``--update`` is an interactive command with an inherited terminal,
+    sudo can simply prompt for a password the way it would if the user typed
+    the command themselves.
+
+    Returns None when there is nothing sensible to run — no npm, or root is
+    needed but there is no terminal to prompt on (a cron job or a pipe), where
+    sudo would hang instead of asking.
+    """
+    npm = shutil.which("npm")
+    if npm is None:
+        return None
+
+    base = [npm, "install", "-g", "gitpulse-tui@latest"]
+
+    root = _npm_global_root()
+    if root is None or os.access(root, os.W_OK):
+        return base
+
+    # Root needed from here on.
+    if os.geteuid() == 0:
+        return base
+
+    sudo = shutil.which("sudo")
+    if sudo is None:
+        return None
+
+    if not (sys.stdin.isatty() and sys.stderr.isatty()):
+        # Non-interactive: only proceed if sudo needs no password.
+        try:
+            probe = subprocess.run(
+                [sudo, "-n", "true"], capture_output=True, timeout=10, check=False
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return [sudo, "-n", *base] if probe.returncode == 0 else None
+
+    return [sudo, *base]
+
+
 def detect_install() -> Install:
     """Work out how this interpreter's GitPulse was installed."""
     exe = Path(sys.executable).resolve()
     prefix = Path(sys.prefix).resolve()
 
-    # npm wrapper — its venv is re-pinned from npm/package.json on every
-    # launch, so upgrading the Python package alone would be reverted.
+    # npm wrapper — upgrade the npm package, not the venv. The wrapper pins an
+    # exact gitpulse-tui==X.Y.Z from its own package.json and re-installs it on
+    # the next launch, so a pip upgrade inside the venv would be reverted.
     try:
         npm_root = _npm_venv_root().resolve()
         if prefix == npm_root or npm_root in exe.parents:
             return Install(
                 method=NPM,
-                command=None,
+                command=_npm_upgrade_command(),
                 manual_hint=(
-                    "Installed via npm. Upgrade with:\n"
-                    "    npm install -g gitpulse-tui@latest\n\n"
-                    "The npm wrapper pins an exact Python package version, so "
-                    "upgrading\nit with pip alone would be undone on the next "
-                    "launch."
+                    "    npm install -g gitpulse-tui@latest\n"
+                    "    (or with sudo, if your global npm prefix needs root)"
                 ),
                 location=str(npm_root),
             )
@@ -114,10 +173,10 @@ def detect_install() -> Install:
             method=SYSTEM,
             command=None,
             manual_hint=(
+                f"    pipx install --force {PACKAGE}\n\n"
                 "This Python is managed by your operating system, so GitPulse "
-                "will not\nmodify it. Install into an isolated environment "
-                "instead:\n"
-                f"    pipx install --force {PACKAGE}"
+                "will not\nmodify it — install into an isolated environment "
+                "instead."
             ),
             location=str(prefix),
         )
@@ -208,14 +267,15 @@ def run_update(check_only: bool = False) -> int:
 
     if check_only or install.command is None:
         print()
-        if install.command is None:
-            print(install.manual_hint)
-        else:
-            print("Upgrade with:")
-            print(install.manual_hint)
+        print("Upgrade with:")
+        print(install.manual_hint)
         return 0
 
-    print(f"Upgrading via {install.method} at {install.location} …")
+    print(f"Upgrading via {install.method} …")
+
+    # Warn before sudo stops for a password, so the prompt is not a surprise.
+    if install.command[0].endswith("sudo") and "-n" not in install.command[:2]:
+        print("Your global npm directory is root-owned; sudo will ask for your password.")
 
     try:
         result = subprocess.run(install.command, check=False)
@@ -231,6 +291,33 @@ def run_update(check_only: bool = False) -> int:
         print(install.manual_hint, file=sys.stderr)
         return result.returncode
 
+    if install.method == NPM:
+        # The npm package is upgraded, but its pinned Python venv is not
+        # rebuilt until the wrapper next runs. Do it now so the very next
+        # command is already on the new version.
+        _sync_npm_venv()
+
     print()
     print(f"Upgraded to gitpulse {latest}. Restart gitpulse to use it.")
     return 0
+
+
+def _sync_npm_venv() -> None:
+    """Rebuild the npm wrapper's pinned venv immediately after an upgrade.
+
+    Invoking the wrapper once is enough: it compares its package.json version
+    against state.json and re-installs the Python package when they differ.
+    Progress goes to stderr, so this stays quiet on stdout.
+    """
+    launcher = shutil.which("gitpulse")
+    if launcher is None:
+        return
+    try:
+        subprocess.run(
+            [launcher, "--version"],
+            stdout=subprocess.DEVNULL,
+            timeout=300,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass  # best effort — the wrapper will self-heal on the next run

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -16,6 +16,20 @@ from gitpulse import update as up
 from gitpulse.update import Install, is_newer, run_update
 
 
+class _Tty:
+    """Stand-in stream that claims to be a terminal."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class _NoTty:
+    """Stand-in stream that is not a terminal (pipe, cron job)."""
+
+    def isatty(self) -> bool:
+        return False
+
+
 class TestVersionComparison:
     @pytest.mark.parametrize(
         "latest,current,expected",
@@ -51,21 +65,78 @@ class TestDetectInstall:
         assert install.command is not None
         assert "--upgrade" in install.command
 
-    def test_npm_install_refuses_to_self_upgrade(self, monkeypatch, tmp_path):
-        """pip-upgrading the npm venv would be undone on the next launch."""
-        # Arrange — pretend this interpreter lives in the npm-managed venv
+    def test_npm_install_upgrades_the_npm_package(self, monkeypatch, tmp_path):
+        """The npm package must be upgraded, not the venv it pins."""
+        # Arrange — pretend this interpreter lives in the npm-managed venv,
+        # in a writable global prefix so no sudo is involved.
         npm_root = tmp_path / "venv"
         npm_root.mkdir()
         monkeypatch.setattr(up, "_npm_venv_root", lambda: npm_root)
         monkeypatch.setattr(up.sys, "prefix", str(npm_root))
+        monkeypatch.setattr(up.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(up, "_npm_global_root", lambda: tmp_path)
 
         # Act
         install = up.detect_install()
 
-        # Assert
+        # Assert — a real command, not a copy-paste hint
         assert install.method == up.NPM
-        assert install.command is None
-        assert "npm install -g gitpulse-tui@latest" in install.manual_hint
+        assert install.command is not None
+        assert install.command[-1] == "gitpulse-tui@latest"
+        assert "install" in install.command
+
+    def test_npm_upgrade_uses_sudo_when_prefix_needs_root(self, monkeypatch, tmp_path):
+        """A root-owned global prefix should prompt for a password, not give up."""
+        # Arrange — unwritable prefix, a terminal available, not already root
+        monkeypatch.setattr(up.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(up, "_npm_global_root", lambda: tmp_path / "root-owned")
+        monkeypatch.setattr(up.os, "access", lambda *a, **k: False)
+        monkeypatch.setattr(up.os, "geteuid", lambda: 1000)
+        monkeypatch.setattr(up.sys, "stdin", _Tty())
+        monkeypatch.setattr(up.sys, "stderr", _Tty())
+
+        # Act
+        command = up._npm_upgrade_command()
+
+        # Assert — plain sudo, so it can prompt interactively
+        assert command is not None
+        assert command[0].endswith("sudo")
+        assert "-n" not in command
+
+    def test_npm_upgrade_never_hangs_without_a_terminal(self, monkeypatch, tmp_path):
+        """With no TTY, sudo would block forever waiting for a password."""
+        # Arrange
+        monkeypatch.setattr(up.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(up, "_npm_global_root", lambda: tmp_path / "root-owned")
+        monkeypatch.setattr(up.os, "access", lambda *a, **k: False)
+        monkeypatch.setattr(up.os, "geteuid", lambda: 1000)
+        monkeypatch.setattr(up.sys, "stdin", _NoTty())
+        monkeypatch.setattr(up.sys, "stderr", _NoTty())
+
+        class Failed:
+            returncode = 1
+
+        monkeypatch.setattr(up.subprocess, "run", lambda *a, **k: Failed())
+
+        # Act
+        command = up._npm_upgrade_command()
+
+        # Assert — refuses rather than hanging on a password prompt
+        assert command is None
+
+    def test_npm_upgrade_skips_sudo_when_already_root(self, monkeypatch, tmp_path):
+        # Arrange
+        monkeypatch.setattr(up.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(up, "_npm_global_root", lambda: tmp_path / "root-owned")
+        monkeypatch.setattr(up.os, "access", lambda *a, **k: False)
+        monkeypatch.setattr(up.os, "geteuid", lambda: 0)
+
+        # Act
+        command = up._npm_upgrade_command()
+
+        # Assert
+        assert command is not None
+        assert not command[0].endswith("sudo")
 
     def test_externally_managed_python_is_not_touched(self, monkeypatch, tmp_path):
         """PEP 668 marks distro Pythons where pip must not write."""
@@ -180,3 +251,33 @@ class TestRunUpdate:
         # Assert
         assert code == 0
         assert "newer or unpublished" in capsys.readouterr().out
+
+    def test_npm_upgrade_syncs_the_pinned_venv(self, monkeypatch, capsys):
+        """After upgrading the npm package its venv is still on the old pin."""
+        # Arrange
+        calls = []
+
+        class Ok:
+            returncode = 0
+
+        def fake_run(cmd, *a, **k):
+            calls.append(cmd)
+            return Ok()
+
+        monkeypatch.setattr(up, "__version__", "1.0.0")
+        monkeypatch.setattr(up, "fetch_latest_version", lambda timeout=5.0: "9.9.9")
+        monkeypatch.setattr(up.subprocess, "run", fake_run)
+        monkeypatch.setattr(up.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(
+            up, "detect_install",
+            lambda: Install(up.NPM, ["/usr/bin/npm", "install"], "hint", "/x"),
+        )
+
+        # Act
+        code = run_update()
+
+        # Assert — the wrapper is invoked afterwards to rebuild its venv
+        assert code == 0
+        assert any("gitpulse" in str(c[0]) for c in calls[1:]), (
+            "npm upgrade did not trigger a venv sync"
+        )


### PR DESCRIPTION
You were right — `--update` that prints a command you then have to type yourself is pointless. Fixed: it now runs the upgrade.

## What was wrong

The npm branch returned `command=None`, so `--update` printed the command and stopped:

```console
$ gitpulse --update
gitpulse 1.2.18 is available.

Installed via npm. Upgrade with:
    npm install -g gitpulse-tui@latest
```

My original caution was aimed at the wrong target. The genuine constraint is that the npm wrapper pins `gitpulse-tui==X.Y.Z` from its own `package.json` and restores it on the next launch — that rules out upgrading the **venv** with pip. It says nothing against upgrading the **npm package**, which is precisely the right thing to do. It just was never wired up.

## What it does now

```console
$ gitpulse --update
gitpulse 1.2.18 is available.
Upgrading via npm …
Your global npm directory is root-owned; sudo will ask for your password.
[sudo] password for lebi:
...
Upgraded to gitpulse 1.2.18. Restart gitpulse to use it.
```

- **Runs the npm upgrade** for npm installs.
- **Prompts for sudo when needed.** Global npm prefixes are usually root-owned (`/usr/lib/node_modules` on this machine). `--update` is interactive with an inherited terminal, so sudo can simply ask for a password exactly as it would if you typed the command yourself. A writable prefix, or already running as root, skips sudo entirely.
- **Warns before the prompt appears**, so it doesn't look like a hang.
- **Rebuilds the pinned venv afterwards.** Upgrading the npm package alone leaves its venv on the old pin until the wrapper next runs — so the wrapper is invoked once immediately, and the next command is already on the new version instead of bootstrapping mid-run.

### The one case that still refuses

No TTY (cron, a pipe): sudo would block forever waiting for input nobody can give. There it falls back to `sudo -n` and refuses unless credentials are already cached. Refusing beats hanging.

PEP 668 also still refuses — an OS-managed Python is a case where writing is the *wrong action*, not a permissions hurdle to work around.

## Verification

Confirmed against the real npm install on this machine:

```
method : npm
command: /usr/bin/sudo /usr/bin/npm install -g gitpulse-tui@latest
```

Tests 211 → **215**, including that sudo is used with a TTY, skipped when already root, and never used non-interactively without cached credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
