### PR TITLE
fix(install): use portable sed so the scripts work on macOS

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -187,3 +187,26 @@ pre-seeded stale alias (removed) and a foreign `~/.local/bin/gitpulse` pointing
 at `/usr/bin/gitpulse` (correctly left in place). The `readlink -f` variant was
 caught failing during that test — `.venv` is deleted first, so the link is
 dangling and `-f` returned empty, skipping removal.
+
+---
+
+## 2026-08-10 — install.sh / uninstall.sh failed on macOS (GNU-only `sed -i`)
+
+**Symptom:** Reported via #43. On macOS the installer's alias cleanup aborts
+with `sed: 1: "...": invalid command code`, so a stale `alias gitpulse=` from an
+older source install is never removed and keeps shadowing the real binary.
+
+**Root cause:** Both scripts used `sed -i '<script>' "$FILE"`. GNU sed accepts
+`-i` with no argument; BSD/macOS sed reads the next token as the backup suffix
+and then treats the filename as the script. Every in-place edit in both scripts
+was affected.
+
+**Fix:** `install.sh:67` and `uninstall.sh:73` — added a `sed_delete()` helper
+that edits via `mktemp` and writes back with `cat`, which is portable and also
+preserves the file's permissions and ownership (unlike `mv`). Also extended the
+rc-file list to include `~/.zprofile`, which macOS zsh users commonly use.
+
+**Verified:** Ran both scripts with a BSD-style `sed` shim first on PATH that
+rejects bare `-i` the way macOS does — alias removed cleanly, `PATH` line and
+file permissions intact. `tests/test_shell_scripts.py` guards it; confirmed the
+test fails when `sed -i` is reintroduced.

--- a/install.sh
+++ b/install.sh
@@ -62,10 +62,21 @@ echo -e "   ${GREEN}✓ Linked $LINK → .venv/bin/gitpulse${NC}"
 
 # Remove aliases written by older versions of this installer; they point at an
 # absolute path and would take precedence over the symlink.
-for RC in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile"; do
+#
+# GNU sed takes `-i` with no argument; BSD/macOS sed requires an explicit
+# (possibly empty) backup suffix, so `sed -i <script>` fails there with
+# "invalid command code". Edit to a temp file instead — portable everywhere.
+sed_delete() {
+    local script="$1" file="$2" tmp
+    tmp="$(mktemp)" || return 1
+    sed "$script" "$file" > "$tmp" && cat "$tmp" > "$file"
+    rm -f "$tmp"
+}
+
+for RC in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.zprofile"; do
     [[ -f "$RC" ]] || continue
     if grep -q "alias gitpulse=" "$RC" 2>/dev/null; then
-        sed -i '/^# GitPulse TUI$/d; /alias gitpulse=/d' "$RC"
+        sed_delete '/^# GitPulse TUI$/d; /alias gitpulse=/d' "$RC"
         echo -e "   ${GREEN}✓ Removed the old alias from $(basename "$RC")${NC}"
     fi
 done

--- a/tests/test_shell_scripts.py
+++ b/tests/test_shell_scripts.py
@@ -1,0 +1,46 @@
+"""
+Portability guards on install.sh / uninstall.sh.
+
+These scripts run on the user's machine before anything Python does, so a
+GNU-only construct is a hard install failure on macOS with no fallback path.
+Reported in issue #43.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = [ROOT / "install.sh", ROOT / "uninstall.sh"]
+
+
+@pytest.mark.parametrize("script", SCRIPTS, ids=lambda p: p.name)
+class TestShellPortability:
+    def test_script_exists(self, script):
+        assert script.is_file()
+
+    def test_no_gnu_only_sed_in_place(self, script):
+        """`sed -i <script>` is GNU-only; BSD/macOS needs a backup suffix."""
+        offenders = []
+        for lineno, line in enumerate(script.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue  # commentary explaining the pitfall is fine
+            # Match `sed -i` NOT followed by a quoted backup suffix.
+            if re.search(r"\bsed\s+-i(?!\s*(''|\"\"))", stripped):
+                offenders.append(f"{script.name}:{lineno}: {stripped}")
+
+        assert not offenders, (
+            "GNU-only `sed -i` found; fails on macOS with 'invalid command "
+            "code':\n  " + "\n  ".join(offenders)
+        )
+
+    def test_syntax_is_valid(self, script):
+        result = subprocess.run(
+            ["bash", "-n", str(script)], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -69,19 +69,27 @@ fi
 # ── 4. Remove alias/PATH from shell rc files ───────────────────────────────
 echo -e "${YELLOW}▸ Removing shell configuration...${NC}"
 
-RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile")
+# GNU sed takes `-i` with no argument; BSD/macOS sed requires an explicit
+# backup suffix, so `sed -i <script>` fails there with "invalid command code".
+# Edit via a temp file instead — portable everywhere. Writing back with `cat`
+# rather than `mv` keeps the original file's permissions and ownership.
+sed_delete() {
+    local script="$1" file="$2" tmp
+    tmp="$(mktemp)" || return 1
+    sed "$script" "$file" > "$tmp" && cat "$tmp" > "$file"
+    rm -f "$tmp"
+}
+
+RC_FILES=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.zprofile")
 
 for RC in "${RC_FILES[@]}"; do
     [[ -f "$RC" ]] || continue
     if grep -q "gitpulse\|GitPulse TUI" "$RC" 2>/dev/null; then
         # Remove the GitPulse TUI comment line, the alias line, and the PATH line
-        sed -i '/# GitPulse TUI/d' "$RC"
-        sed -i '/alias gitpulse=/d' "$RC"
-        sed -i '/gitpulse.*PATH/d' "$RC"
-        # Also remove any blank line that was added before the alias block
-        # (safe: collapses multiple consecutive blank lines to one)
-        sed -i '/^$/N;/^\n$/d' "$RC"
-        echo -e "   ${GREEN}✓ Removed from $(basename $RC)${NC}"
+        sed_delete '/# GitPulse TUI/d; /alias gitpulse=/d; /gitpulse.*PATH/d' "$RC"
+        # Collapse the blank line the old installer left behind
+        sed_delete '/^$/N;/^\n$/D' "$RC"
+        echo -e "   ${GREEN}✓ Removed from $(basename "$RC")${NC}"
     fi
 done
 


### PR DESCRIPTION
Found while investigating #43.

## The bug

Both `install.sh` and `uninstall.sh` used GNU-only in-place sed:

```bash
sed -i '/alias gitpulse=/d' "$RC"          # GNU: fine
sed -i '' '/alias gitpulse=/d' "$RC"       # BSD/macOS: needs the empty suffix
```

On macOS the first form fails with `sed: 1: "...": invalid command code`, because BSD sed reads the token after `-i` as a backup suffix and then treats the filename as the script.

The consequence is worse than a cosmetic error. `install.sh`'s alias cleanup — added in #41 precisely so users upgrading from the old source installer stop being shadowed by a stale `alias gitpulse=` — **silently aborts on macOS**. That's exactly the state the reporter in #43 is stuck in: `npm install -g` succeeds, but an ancient alias keeps winning the name, so they still see `gitpulse 1.1.0`.

## The fix

A `sed_delete()` helper in both scripts that edits via `mktemp` and writes back with `cat`:

```bash
sed_delete() {
    local script="$1" file="$2" tmp
    tmp="$(mktemp)" || return 1
    sed "$script" "$file" > "$tmp" && cat "$tmp" > "$file"
    rm -f "$tmp"
}
```

`cat` rather than `mv` deliberately — it preserves the target file's permissions and ownership, which matters for dotfiles.

Also:
- Collapsed three sequential `sed` calls in `uninstall.sh` into one.
- Added `~/.zprofile` to the rc files both scripts scan. macOS zsh users commonly keep shell config there, and neither script looked at it.

## Verification

Ran both scripts with a BSD-style `sed` shim first on `PATH` that rejects bare `-i` the way macOS does:

```
✓ Linked /tmp/bsdtest/home/.local/bin/gitpulse → .venv/bin/gitpulse
✓ Removed the old alias from .bashrc
✓ Removed the old alias from .zshrc
```

No `invalid command code`. The alias and its `# GitPulse TUI` comment were removed, the unrelated `export PATH=...` line survived, and permissions stayed `644`. The uninstall path was checked the same way.

`tests/test_shell_scripts.py` greps both scripts for the GNU-only form and runs `bash -n` on each. I confirmed it actually catches the regression by reintroducing `sed -i` and watching it fail.

215 → **221** tests.

## Note on #43

This fix does not by itself resolve #43 — the reporter's stale `gitpulse` predates npm distribution entirely (`1.1.0` was never published to npm or PyPI), so they need to remove the shadowing alias or file by hand. But it does mean the installer will clean it up automatically for the next macOS user in that position, instead of failing halfway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
