### PR TITLE
fix(install): verify the install instead of assuming it worked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,58 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint the installer scripts
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          shellcheck install.sh uninstall.sh
+
+  # The installers only ever run on a user's own machine, so exercise them on
+  # both a GNU userland and a BSD/macOS one. Issue #43 was a GNU-only `sed -i`
+  # that no Linux job could have caught.
+  installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Seed a stale alias from the old installer
+        run: |
+          printf '# GitPulse TUI\nalias gitpulse="/dead/path/python -m gitpulse"\n' >> "$HOME/.bashrc"
+          printf '# GitPulse TUI\nalias gitpulse="/dead/path/python -m gitpulse"\n' >> "$HOME/.zshrc"
+
+      - name: Run the installer
+        run: ./install.sh
+
+      - name: The stale alias must be gone
+        run: |
+          if grep -q "alias gitpulse=" "$HOME/.bashrc" "$HOME/.zshrc"; then
+            echo "installer left a stale alias behind"; exit 1
+          fi
+
+      - name: The installed command must run
+        run: "$HOME/.local/bin/gitpulse --version"
+
+      - name: Run the uninstaller
+        run: echo y | ./uninstall.sh
+
+      - name: Everything must be gone
+        run: |
+          test ! -e "$HOME/.local/bin/gitpulse" || { echo "symlink survived"; exit 1; }
+          test ! -d .venv || { echo ".venv survived"; exit 1; }
+
   package:
     runs-on: ubuntu-latest
     steps:

--- a/FIXES.md
+++ b/FIXES.md
@@ -210,3 +210,39 @@ rc-file list to include `~/.zprofile`, which macOS zsh users commonly use.
 rejects bare `-i` the way macOS does — alias removed cleanly, `PATH` line and
 file permissions intact. `tests/test_shell_scripts.py` guards it; confirmed the
 test fails when `sed -i` is reintroduced.
+
+---
+
+## 2026-08-10 — Installer reported success while a stale copy shadowed it
+
+**Symptom:** The root cause behind #43. `install.sh` printed
+"✅ GitPulse installed successfully!" even when another `gitpulse` earlier on
+`PATH` — or an alias in the live shell — would run instead. The user then sees
+an old version and reasonably concludes the install failed.
+
+**Root cause:** The installer never verified its own result. It created the
+symlink and declared victory without checking what `gitpulse` actually
+resolved to.
+
+**Fix:** `install.sh:93` — a verification step that resolves `gitpulse`,
+compares it to the symlink just created, and on mismatch prints the offending
+path plus the exact removal command for that install type (pipx / npm / pip /
+plain file). The closing banner now reports ⚠ rather than ✅ when shadowed or
+when `~/.local/bin` is off `PATH`. It also runs `gitpulse --version` to prove
+the venv works, and warns when an alias is still loaded in the current shell.
+`uninstall.sh:96` reports any `gitpulse` that still resolves afterwards.
+
+**Also fixed in the same pass:**
+- Python discovery probed only `python3`; now tries `python3`/`python`/`py` and
+  asks the interpreter for its own version instead of parsing strings.
+- venv and pip failures were swallowed by `set -e`; both now print the real
+  error plus the fix (`apt install python3-venv` for the common Debian case).
+- `$VENV/bin` was hardcoded; now detects `Scripts/` for Git Bash on Windows.
+- `npm/bin/gitpulse.js` registered `SIGTERM`/`SIGHUP` unconditionally, which
+  can throw on Windows; each registration is now guarded.
+
+**Verified:** Sandboxed installs covering a stale binary earlier on `PATH`, a
+clean install, `~/.local/bin` missing from `PATH`, no Python, a Python without
+`venv`, and paths containing spaces. shellcheck clean. CI now runs shellcheck
+and executes install + uninstall on **both ubuntu-latest and macos-latest** —
+the macOS job is what would have caught #43 before release.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,37 @@ Press `?` inside the app for the full cheat sheet.
 ## Requirements
 
 - Python 3.10+
-- Linux / macOS
+- git on your `PATH`
+
+| Platform | Supported install methods |
+|---|---|
+| Linux | `pip` / `pipx`, `npm`, `./install.sh` |
+| macOS | `pip` / `pipx`, `npm`, `./install.sh` |
+| Windows | `pip` / `pipx`, `npm` |
+
+On Windows, use `pipx install gitpulse-tui` (or npm). `install.sh` is a bash
+script for source installs and is not supported there — the packaged installs
+require no shell scripting and work on all three platforms.
+
+Windows terminal note: use **Windows Terminal** rather than the legacy console
+host. Textual needs a terminal with modern ANSI support, and `conhost.exe`
+renders the dashboard poorly.
+
+### If `gitpulse` runs the wrong version
+
+Almost always another copy earlier on your `PATH`, or a leftover shell alias
+from an old source install:
+
+```bash
+type -a gitpulse          # bash/zsh — shows aliases and every PATH match
+where.exe gitpulse        # Windows
+```
+
+Remove whichever one is winning (`pip uninstall gitpulse-tui`,
+`npm uninstall -g gitpulse-tui`, `pipx uninstall gitpulse-tui`, or delete the
+stale `alias gitpulse=` line from your shell rc file), then open a new
+terminal. `./install.sh` now detects this case and tells you which command to
+run.
 
 ## Documentation
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ set -e
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV="$REPO_DIR/.venv"
 
+RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
@@ -20,29 +21,66 @@ echo -e "   Git Repo Dashboard TUI"
 echo "──────────────────────────────────────"
 
 # ── 1. Check Python ────────────────────────────────────────────────────────
+# Probe several names: `python3` is absent on some Windows/Git Bash setups and
+# on minimal images where only `python` exists. Ask the interpreter for its own
+# version rather than parsing a version string.
 echo -e "${YELLOW}▸ Checking Python version...${NC}"
-if ! command -v python3 &>/dev/null; then
-    echo "❌ python3 not found. Install Python 3.10+ and try again."
+
+PYTHON=""
+for candidate in python3 python py; do
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    if "$candidate" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+        PYTHON="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$PYTHON" ]]; then
+    echo -e "${RED}❌ Python 3.10+ is required but was not found.${NC}"
+    echo ""
+    echo "   macOS:   brew install python@3.12"
+    echo "   Debian:  sudo apt install python3 python3-venv"
+    echo "   Fedora:  sudo dnf install python3"
+    echo "   Windows: https://www.python.org/downloads/"
     exit 1
 fi
-PY_VER=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-PY_MAJOR=$(echo $PY_VER | cut -d. -f1)
-PY_MINOR=$(echo $PY_VER | cut -d. -f2)
-if [[ $PY_MAJOR -lt 3 ]] || [[ $PY_MAJOR -eq 3 && $PY_MINOR -lt 10 ]]; then
-    echo "❌ Python 3.10+ required (found $PY_VER)."
-    exit 1
-fi
-echo -e "   ${GREEN}✓ Python $PY_VER${NC}"
+
+PY_VER="$("$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+echo -e "   ${GREEN}✓ Python $PY_VER ($PYTHON)${NC}"
 
 # ── 2. Create virtual environment ──────────────────────────────────────────
 echo -e "${YELLOW}▸ Setting up virtual environment...${NC}"
-python3 -m venv "$VENV"
+if ! "$PYTHON" -m venv "$VENV" 2>/tmp/gitpulse-venv-err; then
+    echo -e "${RED}❌ Could not create a virtual environment.${NC}"
+    sed 's/^/   /' /tmp/gitpulse-venv-err 2>/dev/null | tail -5
+    echo ""
+    echo "   Debian/Ubuntu users usually need:  sudo apt install python3-venv"
+    rm -f /tmp/gitpulse-venv-err
+    exit 1
+fi
+rm -f /tmp/gitpulse-venv-err
 echo -e "   ${GREEN}✓ Created .venv${NC}"
 
 # ── 3. Install dependencies ────────────────────────────────────────────────
+# POSIX venvs put executables in bin/; Windows venvs (Git Bash, MSYS) use
+# Scripts/. Detect rather than assume, so the script also works under Git Bash.
+if [[ -d "$VENV/Scripts" ]]; then
+    VENV_BIN="$VENV/Scripts"
+else
+    VENV_BIN="$VENV/bin"
+fi
+
 echo -e "${YELLOW}▸ Installing dependencies...${NC}"
-"$VENV/bin/pip" install --quiet --upgrade pip 2>/dev/null || true
-"$VENV/bin/pip" install --quiet -e "$REPO_DIR"
+"$VENV_BIN/python" -m pip install --quiet --upgrade pip 2>/dev/null || true
+if ! "$VENV_BIN/python" -m pip install --quiet -e "$REPO_DIR" 2>/tmp/gitpulse-pip-err; then
+    echo -e "${RED}❌ Dependency installation failed.${NC}"
+    sed 's/^/   /' /tmp/gitpulse-pip-err 2>/dev/null | tail -8
+    echo ""
+    echo "   If you are offline, connect and re-run ./install.sh"
+    rm -f /tmp/gitpulse-pip-err
+    exit 1
+fi
+rm -f /tmp/gitpulse-pip-err
 echo -e "   ${GREEN}✓ Installed textual, rich, gitpython${NC}"
 
 # ── 4. Expose the `gitpulse` command ───────────────────────────────────────
@@ -52,7 +90,7 @@ echo -e "   ${GREEN}✓ Installed textual, rich, gitpython${NC}"
 # it shadows any other GitPulse install (pip, pipx, npm) for the whole shell.
 echo -e "${YELLOW}▸ Exposing the 'gitpulse' command...${NC}"
 
-CONSOLE_SCRIPT="$VENV/bin/gitpulse"
+CONSOLE_SCRIPT="$VENV_BIN/gitpulse"
 LINK_DIR="$HOME/.local/bin"
 LINK="$LINK_DIR/gitpulse"
 
@@ -81,15 +119,75 @@ for RC in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.zprofile"
     fi
 done
 
-if ! echo ":$PATH:" | grep -q ":$LINK_DIR:"; then
+# ── 5. Verify the command actually resolves to what we just installed ──────
+# Reporting success while a stale binary or alias wins the name is the single
+# most confusing failure this installer can produce (see issue #43), so check
+# rather than assume.
+echo -e "${YELLOW}▸ Verifying...${NC}"
+
+PATH_OK=1
+SHADOWED=0
+if ! printf '%s' ":$PATH:" | grep -q ":$LINK_DIR:"; then
+    PATH_OK=0
     echo -e "   ${YELLOW}! $LINK_DIR is not on your PATH${NC}"
-    echo -e "     bash/zsh:  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
-    echo -e "     fish:      fish_add_path ~/.local/bin"
+    echo -e "     bash:  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+    echo -e "     zsh:   echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
+    echo -e "     fish:  fish_add_path ~/.local/bin"
 fi
 
-# ── 5. Done ────────────────────────────────────────────────────────────────
+# `command -v` reflects the PATH this script sees. A login shell may differ,
+# but a conflict here is a conflict there too.
+RESOLVED="$(command -v gitpulse 2>/dev/null || true)"
+
+if [[ $PATH_OK -eq 1 && -n "$RESOLVED" && "$RESOLVED" != "$LINK" ]]; then
+    SHADOWED=1
+    echo -e "   ${RED}✗ Another 'gitpulse' takes precedence:${NC}"
+    echo -e "     ${RED}$RESOLVED${NC}"
+    echo ""
+    echo -e "     That one will run instead of the version just installed."
+    echo -e "     Remove it, then re-open your terminal:"
+    echo ""
+    case "$RESOLVED" in
+        *"/.local/pipx/"*|*"/pipx/venvs/"*)
+            echo -e "       ${CYAN}pipx uninstall gitpulse-tui${NC}" ;;
+        *"/node_modules/"*|*"/npm/"*)
+            echo -e "       ${CYAN}npm uninstall -g gitpulse-tui${NC}" ;;
+        *)
+            echo -e "       ${CYAN}pip uninstall gitpulse-tui${NC}   # if pip installed it"
+            echo -e "       ${CYAN}rm '$RESOLVED'${NC}               # otherwise" ;;
+    esac
+    echo ""
+elif [[ $PATH_OK -eq 1 ]]; then
+    # Confirm the symlink really launches: a broken venv would surface here
+    # rather than the first time the user runs it.
+    if INSTALLED_VER="$("$LINK" --version 2>/dev/null)"; then
+        echo -e "   ${GREEN}✓ $INSTALLED_VER${NC}"
+    else
+        echo -e "   ${RED}✗ '$LINK' did not run — the virtualenv may be broken.${NC}"
+        echo -e "     Try: ${CYAN}rm -rf '$VENV' && ./install.sh${NC}"
+        exit 1
+    fi
+fi
+
+# An alias defined in the *current* shell outlives this script and beats PATH.
+# The rc files were already cleaned above; warn about the live session too.
+if [[ -n "${BASH_VERSION:-}" ]] && alias gitpulse >/dev/null 2>&1; then
+    echo -e "   ${YELLOW}! This shell still has a 'gitpulse' alias loaded.${NC}"
+    echo -e "     Run ${CYAN}unalias gitpulse${NC} or open a new terminal."
+fi
+
+# ── 6. Done ────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${BOLD}${GREEN}✅ GitPulse installed successfully!${NC}"
+if [[ $SHADOWED -eq 1 ]]; then
+    echo -e "${BOLD}${YELLOW}⚠  GitPulse installed, but another copy shadows it.${NC}"
+    echo -e "   Resolve the conflict above, or run it directly:"
+    echo -e "   ${CYAN}$LINK${NC}"
+elif [[ $PATH_OK -eq 0 ]]; then
+    echo -e "${BOLD}${YELLOW}⚠  GitPulse installed — add $LINK_DIR to your PATH.${NC}"
+    echo -e "   Until then, run it directly: ${CYAN}$LINK${NC}"
+else
+    echo -e "${BOLD}${GREEN}✅ GitPulse installed successfully!${NC}"
+fi
 echo ""
 echo -e "  ${BOLD}Run it with:${NC}"
 echo ""

--- a/npm/bin/gitpulse.js
+++ b/npm/bin/gitpulse.js
@@ -81,8 +81,15 @@ function main() {
       }
     }
   };
-  process.on("SIGINT", () => forward("SIGINT"));
-  process.on("SIGTERM", () => forward("SIGTERM"));
+  // Windows has no real POSIX signals; Node emulates SIGINT for Ctrl+C but
+  // registering SIGTERM/SIGHUP there can throw, so guard each registration.
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    try {
+      process.on(signal, () => forward(signal));
+    } catch (_) {
+      /* unsupported on this platform */
+    }
+  }
 
   child.on("error", (err) => {
     if (err && err.code === "ENOENT") {

--- a/tests/test_shell_scripts.py
+++ b/tests/test_shell_scripts.py
@@ -44,3 +44,31 @@ class TestShellPortability:
             ["bash", "-n", str(script)], capture_output=True, text=True
         )
         assert result.returncode == 0, result.stderr
+
+    def test_no_gnu_only_readlink_f(self, script):
+        """`readlink -f` is absent on stock macOS (needs coreutils)."""
+        offenders = [
+            f"{script.name}:{n}: {ln.strip()}"
+            for n, ln in enumerate(script.read_text().splitlines(), 1)
+            if re.search(r"\breadlink\s+-f\b", ln) and not ln.strip().startswith("#")
+        ]
+        assert not offenders, "readlink -f is unavailable on stock macOS:\n  " + "\n  ".join(offenders)
+
+    def test_no_gnu_only_grep_flags(self, script):
+        """`grep -P` (PCRE) is not compiled into BSD grep."""
+        offenders = [
+            f"{script.name}:{n}"
+            for n, ln in enumerate(script.read_text().splitlines(), 1)
+            if re.search(r"\bgrep\s+(-\w*P|--perl-regexp)", ln)
+            and not ln.strip().startswith("#")
+        ]
+        assert not offenders, f"grep -P is GNU-only: {offenders}"
+
+    def test_venv_bin_dir_is_not_hardcoded(self, script):
+        """Windows venvs use Scripts/, not bin/ — detect, do not assume."""
+        text = script.read_text()
+        if "$VENV/bin" not in text:
+            return  # nothing hardcoded
+        assert "Scripts" in text, (
+            "hardcodes $VENV/bin without a Windows Scripts/ fallback"
+        )

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -93,13 +93,33 @@ for RC in "${RC_FILES[@]}"; do
     fi
 done
 
-# ── 5. Done ────────────────────────────────────────────────────────────────
+# ── 5. Report anything that still answers to `gitpulse` ────────────────────
+# A leftover pip/pipx/npm install is not this script's to remove, but leaving
+# the user to discover it themselves is how #43 happened.
+REMAINING="$(command -v gitpulse 2>/dev/null || true)"
+if [[ -n "$REMAINING" ]]; then
+    echo ""
+    echo -e "${RED}▸ Note: 'gitpulse' still resolves to:${NC}"
+    echo -e "   ${CYAN}$REMAINING${NC}"
+    echo -e "   That is a separate installation. Remove it with one of:"
+    case "$REMAINING" in
+        *"/.local/pipx/"*|*"/pipx/venvs/"*)
+            echo -e "     ${CYAN}pipx uninstall gitpulse-tui${NC}" ;;
+        *"/node_modules/"*|*"/npm/"*)
+            echo -e "     ${CYAN}npm uninstall -g gitpulse-tui${NC}" ;;
+        *)
+            echo -e "     ${CYAN}pip uninstall gitpulse-tui${NC}"
+            echo -e "     ${CYAN}npm uninstall -g gitpulse-tui${NC}"
+            echo -e "     ${CYAN}pipx uninstall gitpulse-tui${NC}" ;;
+    esac
+fi
+
+# ── 6. Done ────────────────────────────────────────────────────────────────
 echo ""
 echo -e "${BOLD}${GREEN}✅ GitPulse uninstalled successfully!${NC}"
 echo ""
-echo -e "  Reload your shell to apply changes:"
-echo -e "   ${CYAN}source ~/.bashrc${NC}   # bash users"
-echo -e "   ${CYAN}source ~/.zshrc${NC}    # zsh users"
+echo -e "  Open a new terminal to clear any 'gitpulse' alias still loaded"
+echo -e "  in this session."
 echo ""
 echo -e "  The repo folder ${CYAN}$REPO_DIR${NC} was kept."
 echo -e "  To fully remove it:  ${CYAN}rm -rf $REPO_DIR${NC}"


### PR DESCRIPTION
Closes the class of bug behind #43, rather than just the instance.

## The real root cause

The GNU-only `sed -i` fixed in #44 was a *symptom*. The actual problem: **`install.sh` never verified its own result.** It created the symlink and printed `✅ GitPulse installed successfully!` without ever checking what `gitpulse` resolves to.

So a stale copy earlier on `PATH` silently won, and the user saw an old version with no explanation. Reproduced exactly:

```console
$ ./install.sh
✅ GitPulse installed successfully!

$ gitpulse --version
gitpulse 1.1.0 (stale)      # ← the installer had no idea
```

## The installer now checks its own work

```console
▸ Verifying...
   ✗ Another 'gitpulse' takes precedence:
     /usr/local/bin/gitpulse

     That one will run instead of the version just installed.
     Remove it, then re-open your terminal:

       pip uninstall gitpulse-tui   # if pip installed it
       rm '/usr/local/bin/gitpulse' # otherwise

⚠  GitPulse installed, but another copy shadows it.
```

- Resolves `gitpulse`, compares against the symlink, and on mismatch names the **exact removal command** for that install type (pipx / npm / pip / plain file).
- Runs `gitpulse --version` so a broken venv surfaces during install, not on first use.
- Warns when an alias is still live in the **current shell** — no rc-file edit can clear that.
- The banner reports ⚠ instead of ✅ when shadowed or when `~/.local/bin` is off `PATH`. Claiming success while the user gets the wrong binary is the bug.

`uninstall.sh` likewise reports any `gitpulse` still resolving afterwards.

## Other portability bugs found in the audit

| Bug | Impact |
|---|---|
| Probed only `python3` | Fails where only `python` exists (Windows, minimal images). Now tries `python3`/`python`/`py` and asks the interpreter its own version instead of parsing with `cut`. |
| venv/pip failures swallowed by `set -e` | Silent abort. Both now print the real error **and** the fix — `apt install python3-venv` for the classic Debian case. |
| `$VENV/bin` hardcoded | Windows venvs use `Scripts/`. Detected now, so Git Bash works. |
| `SIGTERM`/`SIGHUP` registered unconditionally | Can throw on Windows. Each registration guarded. |

## Windows

Documented as **pip / pipx / npm** — those need no shell scripting and already work. `install.sh` stays a source-install tool for Linux/macOS. I verified the npm wrapper's Windows handling is genuinely sound (`py -3` probing, `Scripts/python.exe`, direct `.exe` spawn) rather than assuming it.

Also added a note to use Windows Terminal over legacy `conhost.exe`, which renders Textual poorly.

## Verification

Sandboxed runs covering: stale binary earlier on `PATH`, clean install, `~/.local/bin` missing from `PATH`, no Python at all, a Python without `venv`, and paths containing spaces. Each produced the correct message and exit status.

**shellcheck is clean** on both scripts, and CI now enforces it.

The important addition: **CI runs install + uninstall on `macos-latest` as well as `ubuntu-latest`.** That job is what would have caught #43 before it ever shipped — no Linux-only pipeline could have.

221 → **227** tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
